### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded environment variables by using defineSecret

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "pulselink-functions",
+  "name": "sotext-functions",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pulselink-functions",
+      "name": "sotext-functions",
       "dependencies": {
         "@genkit-ai/firebase": "latest",
         "@genkit-ai/vertexai": "latest",

--- a/functions/src/email.ts
+++ b/functions/src/email.ts
@@ -2,6 +2,7 @@ import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
 import * as nodemailer from "nodemailer";
 import {escapeHtml} from "./security";
+import {defineSecret} from "firebase-functions/params";
 
 // Ensure admin is initialized (handled in index.ts, but safe to check)
 if (admin.apps.length === 0) {
@@ -9,15 +10,28 @@ if (admin.apps.length === 0) {
 }
 const db = admin.firestore();
 
-const transporter = nodemailer.createTransport({
-  service: "gmail",
-  auth: {
-    user: process.env.EMAIL_USER,
-    pass: process.env.EMAIL_PASS,
-  },
-});
+const emailUserSecret = defineSecret("EMAIL_USER");
+const emailPassSecret = defineSecret("EMAIL_PASS");
 
-export const sendEmailNotification = functions.https.onCall(
+// Lazily initialize the transporter inside the function
+// so that defineSecret().value() is available.
+let transporter: nodemailer.Transporter | null = null;
+
+function getTransporter() {
+  if (!transporter) {
+    transporter = nodemailer.createTransport({
+      service: "gmail",
+      auth: {
+        user: emailUserSecret.value(),
+        pass: emailPassSecret.value(),
+      },
+    });
+  }
+  return transporter;
+}
+
+export const sendEmailNotification = functions.runWith(
+    {secrets: [emailUserSecret, emailPassSecret]}).https.onCall(
     async (data, context) => {
       if (!context.auth) {
         throw new functions.https.HttpsError(
@@ -93,7 +107,7 @@ export const sendEmailNotification = functions.https.onCall(
       }
 
       const mailOptions = {
-        from: `SoText <${process.env.EMAIL_USER}>`,
+        from: `SoText <${emailUserSecret.value()}>`,
         to: email,
         subject: subject,
         text: text,
@@ -101,7 +115,7 @@ export const sendEmailNotification = functions.https.onCall(
       };
 
       try {
-        await transporter.sendMail(mailOptions);
+        await getTransporter().sendMail(mailOptions);
         return {success: true};
       } catch (error) {
         console.error("Error sending email", error);

--- a/functions/src/spotify.ts
+++ b/functions/src/spotify.ts
@@ -1,54 +1,63 @@
 import {onCall, HttpsError} from "firebase-functions/v2/https";
 import {logger} from "firebase-functions";
+import {defineSecret} from "firebase-functions/params";
 
 const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
 
-export const getSpotifyAccessToken = onCall(async (request) => {
-  // 1. Authenticate the user
-  if (!request.auth) {
-    throw new HttpsError("unauthenticated", "User must be authenticated.");
-  }
+const spotifyClientId = defineSecret("SPOTIFY_CLIENT_ID");
+const spotifyClientSecret = defineSecret("SPOTIFY_CLIENT_SECRET");
 
-  // 2. Retrieve secrets (assumed to be in process.env for this environment)
-  // In production, use defineSecret() for better security, but process.env matches existing pattern (email.ts).
-  const clientId = process.env.SPOTIFY_CLIENT_ID;
-  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+export const getSpotifyAccessToken = onCall(
+    {secrets: [spotifyClientId, spotifyClientSecret]},
+    async (request) => {
+      // 1. Authenticate the user
+      if (!request.auth) {
+        throw new HttpsError("unauthenticated", "User must be authenticated.");
+      }
 
-  if (!clientId || !clientSecret) {
-    logger.error("Missing Spotify credentials in environment.");
-    throw new HttpsError("internal", "Service configuration error.");
-  }
+      // 2. Retrieve secrets using defineSecret()
+      const clientId = spotifyClientId.value();
+      const clientSecret = spotifyClientSecret.value();
 
-  try {
-    // 3. Request token from Spotify
-    const authHeader = "Basic " + Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+      if (!clientId || !clientSecret) {
+        logger.error("Missing Spotify credentials in environment.");
+        throw new HttpsError("internal", "Service configuration error.");
+      }
 
-    const response = await fetch(SPOTIFY_TOKEN_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Authorization": authHeader,
-      },
-      body: "grant_type=client_credentials",
+      try {
+        // 3. Request token from Spotify
+        const authHeader = "Basic " +
+            Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+
+        const response = await fetch(SPOTIFY_TOKEN_URL, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Authorization": authHeader,
+          },
+          body: "grant_type=client_credentials",
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          logger.error("Spotify API error",
+              {status: response.status, body: errorText});
+          throw new HttpsError(
+              "unavailable", "Failed to communicate with Spotify.");
+        }
+
+        const data = await response.json();
+
+        // 4. Return the token
+        // We only return the access_token and expires_in, not the scope
+        // or type if not needed.
+        return {
+          access_token: data.access_token,
+          expires_in: data.expires_in,
+        };
+      } catch (error) {
+        logger.error("Spotify token fetch failed", error);
+        if (error instanceof HttpsError) throw error;
+        throw new HttpsError("internal", "Failed to retrieve access token.");
+      }
     });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      logger.error("Spotify API error", {status: response.status, body: errorText});
-      throw new HttpsError("unavailable", "Failed to communicate with Spotify.");
-    }
-
-    const data = await response.json();
-
-    // 4. Return the token
-    // We only return the access_token and expires_in, not the scope or type if not needed.
-    return {
-      access_token: data.access_token,
-      expires_in: data.expires_in,
-    };
-  } catch (error) {
-    logger.error("Spotify token fetch failed", error);
-    if (error instanceof HttpsError) throw error;
-    throw new HttpsError("internal", "Failed to retrieve access token.");
-  }
-});


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The functions `getSpotifyAccessToken` and `sendEmailNotification` were previously reading credentials (API keys, passwords) directly from `process.env`. While sometimes necessary, standard environment variables are often broadly available and increase the risk of credential leakage in logs or generalized system environments. 
🎯 **Impact:** If these environment variables were accidentally dumped, it could lead to unauthorized use of the system's email sender or Spotify integration.
🔧 **Fix:** Refactored the code to use `defineSecret()` from `firebase-functions/params`. Secrets are passed explicitly to the function definitions using `{secrets: [...]}` for v2 functions and `.runWith({secrets: [...]})` for v1 functions. Crucially, the external dependency (the `nodemailer` transporter in `email.ts`) was refactored to be lazily initialized within the `onCall` handler to guarantee that `.value()` is only accessed at function runtime when the secret is available.
✅ **Verification:**
1. Ran type checking with `npx tsc --noEmit` and confirmed it successfully passes.
2. Verified that tests and lint checks (apart from existing pre-existing ones) still pass.

---
*PR created automatically by Jules for task [2526207226076545105](https://jules.google.com/task/2526207226076545105) started by @DamienLove*