### PR TITLE
🛡️ Sentinel: [HIGH] Fix generic process.env usage for secrets

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "pulselink-functions",
+  "name": "sotext-functions",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pulselink-functions",
+      "name": "sotext-functions",
       "dependencies": {
         "@genkit-ai/firebase": "latest",
         "@genkit-ai/vertexai": "latest",

--- a/functions/src/email.ts
+++ b/functions/src/email.ts
@@ -1,6 +1,7 @@
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
 import * as nodemailer from "nodemailer";
+import {defineSecret} from "firebase-functions/params";
 import {escapeHtml} from "./security";
 
 // Ensure admin is initialized (handled in index.ts, but safe to check)
@@ -9,16 +10,21 @@ if (admin.apps.length === 0) {
 }
 const db = admin.firestore();
 
-const transporter = nodemailer.createTransport({
-  service: "gmail",
-  auth: {
-    user: process.env.EMAIL_USER,
-    pass: process.env.EMAIL_PASS,
-  },
-});
+const emailUserSecret = defineSecret("EMAIL_USER");
+const emailPassSecret = defineSecret("EMAIL_PASS");
 
-export const sendEmailNotification = functions.https.onCall(
-    async (data, context) => {
+export const sendEmailNotification = functions
+    .runWith({secrets: [emailUserSecret, emailPassSecret]})
+    .https.onCall(async (data, context) => {
+      // Sentinel: Initialize lazily to access secret values securely
+      const transporter = nodemailer.createTransport({
+        service: "gmail",
+        auth: {
+          user: emailUserSecret.value(),
+          pass: emailPassSecret.value(),
+        },
+      });
+
       if (!context.auth) {
         throw new functions.https.HttpsError(
             "unauthenticated", "User must be authenticated");
@@ -93,7 +99,7 @@ export const sendEmailNotification = functions.https.onCall(
       }
 
       const mailOptions = {
-        from: `SoText <${process.env.EMAIL_USER}>`,
+        from: `SoText <${emailUserSecret.value()}>`,
         to: email,
         subject: subject,
         text: text,

--- a/functions/src/spotify.ts
+++ b/functions/src/spotify.ts
@@ -1,18 +1,23 @@
 import {onCall, HttpsError} from "firebase-functions/v2/https";
+import {defineSecret} from "firebase-functions/params";
 import {logger} from "firebase-functions";
 
 const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
 
-export const getSpotifyAccessToken = onCall(async (request) => {
+const spotifyClientIdSecret = defineSecret("SPOTIFY_CLIENT_ID");
+const spotifyClientSecretSecret = defineSecret("SPOTIFY_CLIENT_SECRET");
+
+export const getSpotifyAccessToken = onCall({
+  secrets: [spotifyClientIdSecret, spotifyClientSecretSecret],
+}, async (request) => {
   // 1. Authenticate the user
   if (!request.auth) {
     throw new HttpsError("unauthenticated", "User must be authenticated.");
   }
 
-  // 2. Retrieve secrets (assumed to be in process.env for this environment)
-  // In production, use defineSecret() for better security, but process.env matches existing pattern (email.ts).
-  const clientId = process.env.SPOTIFY_CLIENT_ID;
-  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+  // 2. Retrieve secrets using defineSecret for better security
+  const clientId = spotifyClientIdSecret.value();
+  const clientSecret = spotifyClientSecretSecret.value();
 
   if (!clientId || !clientSecret) {
     logger.error("Missing Spotify credentials in environment.");
@@ -21,7 +26,8 @@ export const getSpotifyAccessToken = onCall(async (request) => {
 
   try {
     // 3. Request token from Spotify
-    const authHeader = "Basic " + Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+    const authHeader = "Basic " +
+      Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
 
     const response = await fetch(SPOTIFY_TOKEN_URL, {
       method: "POST",
@@ -34,14 +40,19 @@ export const getSpotifyAccessToken = onCall(async (request) => {
 
     if (!response.ok) {
       const errorText = await response.text();
-      logger.error("Spotify API error", {status: response.status, body: errorText});
-      throw new HttpsError("unavailable", "Failed to communicate with Spotify.");
+      logger.error("Spotify API error", {
+        status: response.status,
+        body: errorText,
+      });
+      throw new HttpsError(
+          "unavailable", "Failed to communicate with Spotify.");
     }
 
     const data = await response.json();
 
     // 4. Return the token
-    // We only return the access_token and expires_in, not the scope or type if not needed.
+    // We only return the access_token and expires_in,
+    // not the scope or type if not needed.
     return {
       access_token: data.access_token,
       expires_in: data.expires_in,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Hardcoded secrets mapping. Usage of `process.env` generic environment variables mapping can leak secrets to broader context or if someone dumps `process.env`. In Firebase, it is better to manage secrets through Secret Manager using `defineSecret`.
🎯 Impact: Using generic `process.env` can inadvertently expose sensitive configuration data such as the `EMAIL_PASS` (email password) and `SPOTIFY_CLIENT_SECRET` to anywhere that executes within the generic node process space.
🔧 Fix: Migrated `EMAIL_USER`, `EMAIL_PASS`, `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` to use `defineSecret()` from `firebase-functions/params`. Updated `getSpotifyAccessToken` and `sendEmailNotification` cloud functions to register their secret dependencies via `onCall({secrets: [...]})` and `runWith({secrets: [...]})` respectively, and moved their initialization within the execution context to read from `.value()` safely.
✅ Verification: Ran `tsc --noEmit`, `eslint`, and manual codebase inspection. Tests pass successfully.

---
*PR created automatically by Jules for task [18184922030340634654](https://jules.google.com/task/18184922030340634654) started by @DamienLove*