### PR TITLE
🎨 Palette: Focus password input on wrapper click

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2563,6 +2563,7 @@ function App() {
   const settingsSearchRef = useRef(null);
   const contactSearchRef = useRef(null);
   const themeSearchRef = useRef(null);
+  const passwordInputRef = useRef(null);
   const messagesEndRef = useRef(null);
   const [premiumClaimActive, setPremiumClaimActive] = useState(false);
   const [proClaimActive, setProClaimActive] = useState(false);
@@ -4298,8 +4299,9 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordInputRef.current?.focus()}>
                   <input
+                    ref={passwordInputRef}
                     id="login-password"
                     className="login-input"
                     type={showPassword ? "text" : "password"}


### PR DESCRIPTION
**💡 What:** Added a `useRef` to the login password input and an `onClick` handler to its parent `.password-input-wrapper`.
**🎯 Why:** To make the login form more intuitive. Users expect "input-like" containers to focus the input when clicked anywhere inside them. This reduces friction and missed clicks, especially near the show/hide password toggle.
**📸 Before/After:** Before, clicking the empty space in the password wrapper did nothing. Now, it focuses the password input correctly.
**♿ Accessibility:** Improves ease of use by increasing the effective hit area for focusing the input field.

---
*PR created automatically by Jules for task [10054575650946982024](https://jules.google.com/task/10054575650946982024) started by @DamienLove*