### PR TITLE
⚡ Bolt: Replace chained array methods with single-pass loops in useMemo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-28 - Date Allocation in Render Loops
 **Learning:** `new Date()` allocation in hot render loops (like message lists) can be avoided by passing timestamps directly to `Intl.DateTimeFormat.format()`.
 **Action:** Always check if formatting functions accept primitives before wrapping them in objects inside `render` or `map`.
+
+## 2024-05-29 - Array Allocations in useMemo
+**Learning:** The spread operator and `.flat()`, `.filter()`, `.map()` chains create many intermediate objects, blocking the main thread when executed on every update or keystroke in `useMemo`.
+**Action:** Replace functional array pipelines with imperative, single-pass `for` loops within hot `useMemo` hooks.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2806,15 +2806,26 @@ function App() {
   const contactLookup = useMemo(() => {
     const map = {};
     const add = (c) => {
-      const nums = [c.phoneNumber, ...(c.additionalPhones || [])];
-      nums.forEach(n => {
-        if (!n) return;
-        const clean = n.replace(/\D/g, '');
+      if (c.phoneNumber) {
+        const clean = c.phoneNumber.replace(/\D/g, '');
         if (clean) map[clean] = c;
-      });
+      }
+      if (Array.isArray(c.additionalPhones)) {
+        for (let i = 0; i < c.additionalPhones.length; i++) {
+          const n = c.additionalPhones[i];
+          if (n) {
+            const clean = n.replace(/\D/g, '');
+            if (clean) map[clean] = c;
+          }
+        }
+      }
     };
-    deviceContacts.forEach(add);
-    trustedContacts.forEach(add);
+    for (let i = 0; i < deviceContacts.length; i++) {
+      add(deviceContacts[i]);
+    }
+    for (let i = 0; i < trustedContacts.length; i++) {
+      add(trustedContacts[i]);
+    }
     return map;
   }, [deviceContacts, trustedContacts]);
 
@@ -4201,16 +4212,36 @@ function App() {
 
   const combinedThreads = useMemo(() => {
     if (lineInboxMode === 'PER_LINE') return [];
-    const lineFlattened = Object.values(lineThreads).flat();
 
-    // Create a Set of addresses present in the new line threads to filter out legacy duplicates
-    const lineAddresses = new Set(lineFlattened.map(t => t.address).filter(Boolean));
-    const uniqueLegacy = legacyThreads.filter(t => !t.address || !lineAddresses.has(t.address));
+    const lineAddresses = new Set();
+    const filtered = [];
 
-    const all = [...uniqueLegacy, ...lineFlattened];
+    // Process lineThreads
+    const keys = Object.keys(lineThreads);
+    for (let i = 0; i < keys.length; i++) {
+      const threads = lineThreads[keys[i]];
+      if (Array.isArray(threads)) {
+        for (let j = 0; j < threads.length; j++) {
+          const t = threads[j];
+          if (t.address) {
+            lineAddresses.add(t.address);
+          }
+          if (showArchived ? t.archived : !t.archived) {
+            filtered.push(t);
+          }
+        }
+      }
+    }
 
-    // Filter by archive status
-    const filtered = all.filter(t => showArchived ? t.archived : !t.archived);
+    // Process legacyThreads
+    for (let i = 0; i < legacyThreads.length; i++) {
+      const t = legacyThreads[i];
+      if (!t.address || !lineAddresses.has(t.address)) {
+        if (showArchived ? t.archived : !t.archived) {
+          filtered.push(t);
+        }
+      }
+    }
 
     // Sort: Pinned first, then date
     return filtered.sort((a, b) => {


### PR DESCRIPTION
**💡 What:**
Refactored the `contactLookup` and `combinedThreads` `useMemo` hooks in `web/src/App.jsx`. Replaced chained functional array methods (like `.flat()`, `.filter()`, `.map()`) and spread operators (`[...a, ...b]`) with imperative, single-pass `for` loops.

**🎯 Why:**
In React applications, `useMemo` hooks that execute frequently (e.g., during keystrokes or state updates) can become performance bottlenecks if they create many intermediate arrays. The spread operator and chained array methods allocate new memory for each intermediate step, leading to increased Garbage Collection (GC) pressure and main-thread blocking, causing perceived UI lag, especially with large lists like contacts or message threads. 

**📊 Impact:**
Eliminates intermediate array allocations for the `deviceContacts`, `trustedContacts`, `legacyThreads`, and `lineThreads` derivations, directly reducing memory footprint and GC pauses during frequent re-renders. 

**🔬 Measurement:**
Use Chrome DevTools Performance tab to record typing in the Contacts search bar before and after the change. Observe a reduction in the "Scripting" time and fewer GC events.

*(Note: Test failures in `verification.spec.js` and others are pre-existing issues related to the app rebranding from "Beacon" to "SoText" and are unrelated to this optimization).*

---
*PR created automatically by Jules for task [2704893999370360716](https://jules.google.com/task/2704893999370360716) started by @DamienLove*