### PR TITLE
⚡ Bolt: Eliminate intermediate array allocations in useMemo hooks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-28 - Date Allocation in Render Loops
 **Learning:** `new Date()` allocation in hot render loops (like message lists) can be avoided by passing timestamps directly to `Intl.DateTimeFormat.format()`.
 **Action:** Always check if formatting functions accept primitives before wrapping them in objects inside `render` or `map`.
+
+## 2024-05-30 - Eager Array Allocations in React useMemo
+**Learning:** `useMemo` hooks like `combinedThreads` and `contactLookup` heavily used chained array methods (like `.flat()`, `.map()`, `.filter()`) and spread operators. This creates massive intermediate array allocations resulting in memory bloat and blocking the main thread during high-frequency updates or typing.
+**Action:** Replace chained array methods and spread operators with imperative single-pass loops (`for` loops and `push()`) within frequently executing `useMemo` blocks.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2803,18 +2803,33 @@ function App() {
   }, [getContactSearchIndex, contactSearch, deviceContacts]);
 
   // Bolt: Create a unified contact lookup map for avatars
+  // Optimization: Replaced chained array methods (.flat, .forEach) and spread operators
+  // with imperative loops to eliminate intermediate array allocations during render.
   const contactLookup = useMemo(() => {
     const map = {};
     const add = (c) => {
-      const nums = [c.phoneNumber, ...(c.additionalPhones || [])];
-      nums.forEach(n => {
-        if (!n) return;
-        const clean = n.replace(/\D/g, '');
+      const p = c.phoneNumber;
+      if (p) {
+        const clean = p.replace(/\D/g, '');
         if (clean) map[clean] = c;
-      });
+      }
+      const addPhones = c.additionalPhones;
+      if (Array.isArray(addPhones)) {
+        for (let i = 0; i < addPhones.length; i++) {
+          const n = addPhones[i];
+          if (n) {
+            const clean = n.replace(/\D/g, '');
+            if (clean) map[clean] = c;
+          }
+        }
+      }
     };
-    deviceContacts.forEach(add);
-    trustedContacts.forEach(add);
+    for (let i = 0; i < deviceContacts.length; i++) {
+      add(deviceContacts[i]);
+    }
+    for (let i = 0; i < trustedContacts.length; i++) {
+      add(trustedContacts[i]);
+    }
     return map;
   }, [deviceContacts, trustedContacts]);
 
@@ -4199,18 +4214,39 @@ function App() {
     }
   }, [user]);
 
+  // Bolt: Optimization: Replaced chained array methods (.flat, .filter) and spread operators
+  // with imperative loops to eliminate intermediate array allocations during render.
   const combinedThreads = useMemo(() => {
     if (lineInboxMode === 'PER_LINE') return [];
-    const lineFlattened = Object.values(lineThreads).flat();
+
+    const filtered = [];
+    const lineAddresses = new Set();
+    const threadsVals = Object.values(lineThreads);
 
     // Create a Set of addresses present in the new line threads to filter out legacy duplicates
-    const lineAddresses = new Set(lineFlattened.map(t => t.address).filter(Boolean));
-    const uniqueLegacy = legacyThreads.filter(t => !t.address || !lineAddresses.has(t.address));
+    for (let i = 0; i < threadsVals.length; i++) {
+      const threadsArr = threadsVals[i];
+      for (let j = 0; j < threadsArr.length; j++) {
+        const t = threadsArr[j];
+        if (t.address) {
+          lineAddresses.add(t.address);
+        }
+        // Filter by archive status for line threads
+        if (showArchived ? t.archived : !t.archived) {
+          filtered.push(t);
+        }
+      }
+    }
 
-    const all = [...uniqueLegacy, ...lineFlattened];
-
-    // Filter by archive status
-    const filtered = all.filter(t => showArchived ? t.archived : !t.archived);
+    // Process legacy threads and filter by archive status
+    for (let i = 0; i < legacyThreads.length; i++) {
+      const t = legacyThreads[i];
+      if (!t.address || !lineAddresses.has(t.address)) {
+        if (showArchived ? t.archived : !t.archived) {
+          filtered.push(t);
+        }
+      }
+    }
 
     // Sort: Pinned first, then date
     return filtered.sort((a, b) => {


### PR DESCRIPTION
💡 **What**: Replaced chained array methods (`.flat`, `.map`, `.filter`) and spread operators with single-pass imperative `for` loops inside the `combinedThreads` and `contactLookup` `useMemo` hooks.
🎯 **Why**: When processing arrays (especially potentially large lists of device contacts or multi-line synced threads), chained array methods create multiple intermediate arrays on every evaluation. This causes unnecessary garbage collection pressure and can block the main thread, resulting in laggy typing experiences.
📊 **Impact**: Eliminates O(N) array object allocations during UI updates for threads and contacts, reducing overall memory bloat and improving UI responsiveness.
🔬 **Measurement**: Verify that navigating between threads or typing in the search bar feels smoother. To verify the functional correctness, launch the frontend with `?mock_user=true` and confirm contacts and threads load correctly.

---
*PR created automatically by Jules for task [16459543843652780457](https://jules.google.com/task/16459543843652780457) started by @DamienLove*