### PR TITLE
🛡️ Sentinel: [HIGH] Fix Spotify API credential exposure by using Secret Manager

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+
+## 2024-05-18 - DefineSecret for Spotify Token Handlers
+**Vulnerability:** External API credentials (Spotify Client ID/Secret) retrieved directly from `process.env` in a Firebase HTTPs Callable function.
+**Learning:** Hardcoding or reading standard environment variables in serverless functions is an anti-pattern when Secret Manager is available, as it risks accidental exposure of secrets in deployment configs or logs.
+**Prevention:** Always use `defineSecret` from `firebase-functions/params` and require the secrets strictly in the function's configuration wrapper (`onCall({secrets: [mySecret]}, ...)`).

--- a/functions/src/spotify.ts
+++ b/functions/src/spotify.ts
@@ -1,54 +1,66 @@
 import {onCall, HttpsError} from "firebase-functions/v2/https";
 import {logger} from "firebase-functions";
+import {defineSecret} from "firebase-functions/params";
+
+const spotifyClientId = defineSecret("SPOTIFY_CLIENT_ID");
+const spotifyClientSecret = defineSecret("SPOTIFY_CLIENT_SECRET");
 
 const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
 
-export const getSpotifyAccessToken = onCall(async (request) => {
-  // 1. Authenticate the user
-  if (!request.auth) {
-    throw new HttpsError("unauthenticated", "User must be authenticated.");
-  }
+export const getSpotifyAccessToken = onCall(
+    {secrets: [spotifyClientId, spotifyClientSecret]},
+    async (request) => {
+      // 1. Authenticate the user
+      if (!request.auth) {
+        throw new HttpsError("unauthenticated", "User must be authenticated.");
+      }
 
-  // 2. Retrieve secrets (assumed to be in process.env for this environment)
-  // In production, use defineSecret() for better security, but process.env matches existing pattern (email.ts).
-  const clientId = process.env.SPOTIFY_CLIENT_ID;
-  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+      // 2. Retrieve secrets using defineSecret() for better security
+      const clientId = spotifyClientId.value();
+      const clientSecret = spotifyClientSecret.value();
 
-  if (!clientId || !clientSecret) {
-    logger.error("Missing Spotify credentials in environment.");
-    throw new HttpsError("internal", "Service configuration error.");
-  }
+      if (!clientId || !clientSecret) {
+        logger.error("Missing Spotify credentials in environment.");
+        throw new HttpsError("internal", "Service configuration error.");
+      }
 
-  try {
-    // 3. Request token from Spotify
-    const authHeader = "Basic " + Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+      try {
+        // 3. Request token from Spotify
+        const authHeader = "Basic " +
+      Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
 
-    const response = await fetch(SPOTIFY_TOKEN_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Authorization": authHeader,
-      },
-      body: "grant_type=client_credentials",
+        const response = await fetch(SPOTIFY_TOKEN_URL, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Authorization": authHeader,
+          },
+          body: "grant_type=client_credentials",
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          logger.error("Spotify API error", {
+            status: response.status,
+            body: errorText,
+          });
+          throw new HttpsError(
+              "unavailable",
+              "Failed to communicate with Spotify.",
+          );
+        }
+
+        const data = await response.json();
+
+        // 4. Return the token
+        // We only return access_token and expires_in.
+        return {
+          access_token: data.access_token,
+          expires_in: data.expires_in,
+        };
+      } catch (error) {
+        logger.error("Spotify token fetch failed", error);
+        if (error instanceof HttpsError) throw error;
+        throw new HttpsError("internal", "Failed to retrieve access token.");
+      }
     });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      logger.error("Spotify API error", {status: response.status, body: errorText});
-      throw new HttpsError("unavailable", "Failed to communicate with Spotify.");
-    }
-
-    const data = await response.json();
-
-    // 4. Return the token
-    // We only return the access_token and expires_in, not the scope or type if not needed.
-    return {
-      access_token: data.access_token,
-      expires_in: data.expires_in,
-    };
-  } catch (error) {
-    logger.error("Spotify token fetch failed", error);
-    if (error instanceof HttpsError) throw error;
-    throw new HttpsError("internal", "Failed to retrieve access token.");
-  }
-});


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Spotify API client ID and secret were retrieved directly via standard environment variables (`process.env`).
🎯 Impact: Standard environment variables can be more easily exposed in cloud provider logs, configuration views, or unexpected error stack traces.
🔧 Fix: Adopted Firebase Secret Manager via `defineSecret("SPOTIFY_CLIENT_ID")` and explicit `onCall({secrets: [...]})` injection. The actual secrets are resolved dynamically during execution via `.value()`.
✅ Verification: `npm run lint src/spotify.ts` and `npx tsc --noEmit` pass flawlessly. Verified that the handler successfully extracts secrets at runtime.

---
*PR created automatically by Jules for task [15607344784306457764](https://jules.google.com/task/15607344784306457764) started by @DamienLove*