### PR TITLE
🎨 Palette: Make password input wrapper fully interactive

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2522,6 +2522,7 @@ function App() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const passwordInputRef = useRef(null);
   const [authError, setAuthError] = useState('');
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [activePanel, setActivePanel] = useState('inbox');
@@ -4298,8 +4299,9 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordInputRef.current?.focus()}>
                   <input
+                    ref={passwordInputRef}
                     id="login-password"
                     className="login-input"
                     type={showPassword ? "text" : "password"}
@@ -4313,6 +4315,7 @@ function App() {
                     className="password-toggle-btn"
                     onClick={() => setShowPassword(!showPassword)}
                     aria-label={showPassword ? "Hide password" : "Show password"}
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (

--- a/web/tests/login_a11y.spec.js
+++ b/web/tests/login_a11y.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('Login Screen accessibility & focus', async ({ page }) => {
+  await page.goto('/');
+
+  const passwordWrapper = page.locator('.password-input-wrapper');
+  const passwordInput = page.locator('#login-password');
+  const toggleBtn = page.locator('.password-toggle-btn');
+
+  // Verify elements are visible
+  await expect(passwordWrapper).toBeVisible();
+  await expect(passwordInput).toBeVisible();
+  await expect(toggleBtn).toBeVisible();
+
+  // Test click on wrapper focuses input
+  await passwordWrapper.click({ position: { x: 5, y: 5 } }); // Click empty space in wrapper
+  await expect(passwordInput).toBeFocused();
+
+  // Test ARIA attribute toggle
+  await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
+  await toggleBtn.click();
+  await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
+  await expect(passwordInput).toHaveAttribute('type', 'text');
+});


### PR DESCRIPTION
💡 **What**: 
1. The `.password-input-wrapper` container on the login screen now forwards clicks to the underlying password `<input>`.
2. The password visibility toggle button (`.password-toggle-btn`) now includes an `aria-pressed` attribute reflecting its current state.

🎯 **Why**: 
1. **Interaction UX:** Users expect input-like containers (with borders and icons) to be fully interactive. Clicking slightly outside the actual input text area but inside the container boundary previously did nothing, causing friction.
2. **Accessibility:** Screen readers need explicit state indicators for toggle buttons. `aria-pressed` communicates whether the password is currently visible or hidden.

📸 **Before/After**: 
- *Before:* Clicking the empty space next to the eye icon inside the password field did not focus the input. The toggle button did not announce its active state.
- *After:* Clicking anywhere inside the password container focuses the field. Screen readers announce the "pressed" state of the toggle button.

♿ **Accessibility**: 
- Added `aria-pressed={showPassword}` to the password visibility toggle.
- Added `tests/login_a11y.spec.js` Playwright suite to guard against regressions for both the click-to-focus behavior and the ARIA state toggle.

---
*PR created automatically by Jules for task [17896536067606997237](https://jules.google.com/task/17896536067606997237) started by @DamienLove*