### PR TITLE
⚡ Bolt: Prevent array allocation bloat in combinedThreads useMemo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-28 - Date Allocation in Render Loops
 **Learning:** `new Date()` allocation in hot render loops (like message lists) can be avoided by passing timestamps directly to `Intl.DateTimeFormat.format()`.
 **Action:** Always check if formatting functions accept primitives before wrapping them in objects inside `render` or `map`.
+
+## 2024-05-29 - Avoid Chained Array Methods in useMemo
+**Learning:** Chained array methods like `.map().filter()` inside `useMemo` hooks create multiple intermediate array allocations. When executed frequently or with large data sets, this causes memory bloat and blocking main thread rendering.
+**Action:** Replace chained array methods with single-pass imperative loops inside frequently executing `useMemo` blocks to avoid intermediate array allocations.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -4201,19 +4201,36 @@ function App() {
 
   const combinedThreads = useMemo(() => {
     if (lineInboxMode === 'PER_LINE') return [];
-    const lineFlattened = Object.values(lineThreads).flat();
 
-    // Create a Set of addresses present in the new line threads to filter out legacy duplicates
-    const lineAddresses = new Set(lineFlattened.map(t => t.address).filter(Boolean));
-    const uniqueLegacy = legacyThreads.filter(t => !t.address || !lineAddresses.has(t.address));
+    // Bolt: Use imperative loops instead of chained array methods to avoid multiple intermediate allocations
+    const all = [];
+    const lineAddresses = new Set();
 
-    const all = [...uniqueLegacy, ...lineFlattened];
+    // Process line threads
+    const lineGroups = Object.values(lineThreads);
+    for (let i = 0; i < lineGroups.length; i++) {
+      const group = lineGroups[i];
+      for (let j = 0; j < group.length; j++) {
+        const t = group[j];
+        if (t.address) {
+          lineAddresses.add(t.address);
+        }
+        if (showArchived ? t.archived : !t.archived) {
+          all.push(t);
+        }
+      }
+    }
 
-    // Filter by archive status
-    const filtered = all.filter(t => showArchived ? t.archived : !t.archived);
+    // Process legacy threads, filtering out duplicates
+    for (let i = 0; i < legacyThreads.length; i++) {
+      const t = legacyThreads[i];
+      if ((!t.address || !lineAddresses.has(t.address)) && (showArchived ? t.archived : !t.archived)) {
+        all.push(t);
+      }
+    }
 
     // Sort: Pinned first, then date
-    return filtered.sort((a, b) => {
+    return all.sort((a, b) => {
       if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
       return (b.date ?? 0) - (a.date ?? 0);
     });


### PR DESCRIPTION
💡 **What:** Replaced chained array methods (`.flat()`, `.map()`, `.filter()`) and spread operators inside the `combinedThreads` `useMemo` hook in `web/src/App.jsx` with single-pass imperative loops.
🎯 **Why:** Chained array methods allocate intermediate arrays at every step. In frequently executed `useMemo` blocks dealing with thousands of threads, this causes significant memory bloat and garbage collection pauses, blocking the main rendering thread. 
📊 **Impact:** Reduces memory allocation overhead to a single array instantiation for the `combinedThreads` calculation, minimizing garbage collection pauses when switching line inbox modes or archiving status.
🔬 **Measurement:** Can be verified by using Chrome DevTools Performance tab and Memory profiling to observe fewer JS heap allocations when toggling the 'Show Archived' setting or switching lines in the inbox.

---
*PR created automatically by Jules for task [141383980118705855](https://jules.google.com/task/141383980118705855) started by @DamienLove*