### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded API key in config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+
+## 2024-05-28 - Hardcoded Firebase Config in Web Frontend
+**Vulnerability:** The web frontend (`web/src/firebase.js`) contained hardcoded Firebase project identifiers, including the API key, exposing them in the source code repository.
+**Learning:** Hardcoded secrets in client-side code are often exposed in public repositories or to anyone with access to the source code, creating a potential vector for unauthorized access or abuse if not properly restricted by origin and Firestore rules.
+**Prevention:** Always use environment variables (e.g., `import.meta.env.*` in Vite) to inject sensitive configuration values at build time or runtime, as specified in the setup documentation.

--- a/web/src/firebase.js
+++ b/web/src/firebase.js
@@ -6,12 +6,12 @@ import { getStorage } from "firebase/storage";
 import { getAnalytics } from "firebase/analytics";
 
 const firebaseConfig = {
-  apiKey: "AIzaSyDT-dDiNWjpd-5Ek2qxMFIQznxuuW9QvXw",
-  authDomain: "sotextapp.firebaseapp.com",
-  projectId: "sotextapp",
-  storageBucket: "sotextapp.firebasestorage.app",
-  messagingSenderId: "861460679274",
-  appId: "1:861460679274:web:f6179ec058b1c0bf55d813",
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
   measurementId: "G-0NZRE9QGS0"
 };
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The web frontend (`web/src/firebase.js`) contained hardcoded Firebase project identifiers, including the API key, exposing them in the source code repository.
🎯 Impact: Hardcoded secrets in client-side code are often exposed in public repositories or to anyone with access to the source code, creating a potential vector for unauthorized access or abuse if not properly restricted by origin and Firestore rules.
🔧 Fix: Replaced the hardcoded configuration values with environment variables (e.g., `import.meta.env.*` in Vite) as defined in the setup documentation.
✅ Verification: Ensure the frontend application still builds properly with `cd web && pnpm build` and runs correctly when the corresponding `VITE_FIREBASE_*` environment variables are provided.

---
*PR created automatically by Jules for task [2373939979677418140](https://jules.google.com/task/2373939979677418140) started by @DamienLove*