### PR TITLE
🛡️ Sentinel: [HIGH] Fix unprotected environment variables for Spotify secrets

### DIFF
--- a/functions/src/spotify.ts
+++ b/functions/src/spotify.ts
@@ -1,18 +1,23 @@
 import {onCall, HttpsError} from "firebase-functions/v2/https";
 import {logger} from "firebase-functions";
+import {defineSecret} from "firebase-functions/params";
 
 const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
 
-export const getSpotifyAccessToken = onCall(async (request) => {
+const spotifyClientId = defineSecret("SPOTIFY_CLIENT_ID");
+const spotifyClientSecret = defineSecret("SPOTIFY_CLIENT_SECRET");
+
+export const getSpotifyAccessToken = onCall({
+  secrets: [spotifyClientId, spotifyClientSecret],
+}, async (request) => {
   // 1. Authenticate the user
   if (!request.auth) {
     throw new HttpsError("unauthenticated", "User must be authenticated.");
   }
 
-  // 2. Retrieve secrets (assumed to be in process.env for this environment)
-  // In production, use defineSecret() for better security, but process.env matches existing pattern (email.ts).
-  const clientId = process.env.SPOTIFY_CLIENT_ID;
-  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+  // 2. Retrieve secrets using defineSecret() for better security
+  const clientId = spotifyClientId.value();
+  const clientSecret = spotifyClientSecret.value();
 
   if (!clientId || !clientSecret) {
     logger.error("Missing Spotify credentials in environment.");


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Sensitive Spotify API credentials (`SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET`) were being accessed directly via `process.env` in the `getSpotifyAccessToken` function without utilizing the secure Secret Manager infrastructure provided by Firebase (`defineSecret`).
🎯 Impact: Using standard environment variables for sensitive secrets can lead to credential leakage in runtime logs, environment dumps, or misconfigured continuous integration systems.
🔧 Fix: Updated `functions/src/spotify.ts` to retrieve these credentials using `defineSecret` and registered them in the `onCall` function's configuration parameters (`secrets: [spotifyClientId, spotifyClientSecret]`), ensuring they are securely fetched and mapped directly by Google Cloud Secret Manager at runtime.
✅ Verification: Ran `tsc --noEmit` in `functions` and requested code review to verify code correctness. Verified that `spotify.ts` implements `.value()` properly.

---
*PR created automatically by Jules for task [7983415333961610757](https://jules.google.com/task/7983415333961610757) started by @DamienLove*