### PR TITLE
🎨 Palette: UX improvements for inputs and toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2025-04-03 - Static aria-label with aria-pressed for Toggle Buttons
+**Learning:** When implementing accessibility for state toggle buttons (e.g., "Show/Hide Password" or "Show Inbox/Archive"), dynamically changing the `aria-label` based on state can be confusing to screen readers because it doesn't clearly indicate that it's a toggle button. It's better to use a static `aria-label` (e.g., "Toggle password visibility") combined with the `aria-pressed` attribute to properly indicate their active toggled state.
+**Action:** Always use static `aria-label` and dynamic `aria-pressed` or `aria-expanded` attributes for toggle buttons to provide consistent and clear feedback to screen readers.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2112,7 +2112,8 @@ const Sidebar = memo(({
                 onClick={() => setShowArchived(!showArchived)}
                 className={`ghost-btn icon-only ${showArchived ? 'active' : ''}`}
                 title={showArchived ? "Show Inbox" : "Show Archive"}
-                aria-label={showArchived ? "Show Inbox" : "Show Archive"}
+                aria-label="Toggle archive view"
+                aria-pressed={showArchived}
               >
                 {showArchived ? <InboxIcon /> : <ArchiveIcon />}
               </button>
@@ -2210,7 +2211,7 @@ const Sidebar = memo(({
       </div>
       <div className="sidebar-footer">
         {!collapsed && <button onClick={handleLogout} className="ghost-btn">Logout</button>}
-        <button onClick={() => setCollapsed(prev => !prev)} className="ghost-btn icon-only" title={collapsed ? "Expand" : "Collapse"} aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}>
+        <button onClick={() => setCollapsed(prev => !prev)} className="ghost-btn icon-only" title={collapsed ? "Expand" : "Collapse"} aria-label="Toggle sidebar" aria-expanded={!collapsed}>
           {collapsed ? (
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="13 17 18 12 13 7"></polyline><polyline points="6 17 11 12 6 7"></polyline></svg>
           ) : (
@@ -2563,6 +2564,7 @@ function App() {
   const settingsSearchRef = useRef(null);
   const contactSearchRef = useRef(null);
   const themeSearchRef = useRef(null);
+  const passwordInputRef = useRef(null);
   const messagesEndRef = useRef(null);
   const [premiumClaimActive, setPremiumClaimActive] = useState(false);
   const [proClaimActive, setProClaimActive] = useState(false);
@@ -4298,8 +4300,9 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordInputRef.current?.focus()}>
                   <input
+                    ref={passwordInputRef}
                     id="login-password"
                     className="login-input"
                     type={showPassword ? "text" : "password"}
@@ -4312,7 +4315,8 @@ function App() {
                     type="button"
                     className="password-toggle-btn"
                     onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (


### PR DESCRIPTION
💡 **What:** Added a `useRef` to the password input and forwarded focus to it when clicking the `password-input-wrapper` container. Also improved screen reader accessibility for three main toggle buttons (password visibility, archive view, and sidebar collapse) by adding static `aria-label`s paired with dynamic `aria-pressed` or `aria-expanded` attributes.

🎯 **Why:** 
1. Clicking the "Password" container didn't focus the actual input field, which violates user expectations for inputs enclosed in styling wrappers.
2. Toggle buttons that dynamically change their `aria-label` based on state can be confusing to screen readers because they don't always indicate they are toggleable. Using a static label with `aria-pressed` correctly announces the button and its current active state.

📸 **Before/After:**
The password input container is now clickable anywhere to gain focus. Screen readers will now announce "Toggle password visibility, pressed" instead of dynamically shifting between "Show password" and "Hide password".

♿ **Accessibility:**
- Added `aria-label="Toggle password visibility"` and `aria-pressed={showPassword}` to the password visibility toggle.
- Added `aria-label="Toggle archive view"` and `aria-pressed={showArchived}` to the Inbox/Archive toggle.
- Added `aria-label="Toggle sidebar"` and `aria-expanded={!collapsed}` to the Sidebar collapse toggle.

---
*PR created automatically by Jules for task [11135508413841525520](https://jules.google.com/task/11135508413841525520) started by @DamienLove*