### PR TITLE
🎨 Palette: Improve password input accessibility and focus UX

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2522,6 +2522,7 @@ function App() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const passwordInputRef = useRef(null);
   const [authError, setAuthError] = useState('');
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [activePanel, setActivePanel] = useState('inbox');
@@ -4298,9 +4299,10 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordInputRef.current?.focus()}>
                   <input
                     id="login-password"
+                    ref={passwordInputRef}
                     className="login-input"
                     type={showPassword ? "text" : "password"}
                     value={password}
@@ -4311,9 +4313,13 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
-                    title={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
+                    title="Toggle password visibility"
                   >
                     {showPassword ? (
                       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/web/tests/login_ux.spec.js
+++ b/web/tests/login_ux.spec.js
@@ -17,11 +17,7 @@ test.describe('Login UX Improvements', () => {
     const toggleBtn = page.locator('.password-toggle-btn');
     await expect(toggleBtn).toBeVisible();
 
-    // Initially hidden (password type)
-    await expect(toggleBtn).toHaveAttribute('title', 'Show password');
-
-    // Click to show
-    await toggleBtn.click();
-    await expect(toggleBtn).toHaveAttribute('title', 'Hide password');
+    // Check static title
+    await expect(toggleBtn).toHaveAttribute('title', 'Toggle password visibility');
   });
 });


### PR DESCRIPTION
### 💡 What
Improved the UX and accessibility of the password input field on the login page:
1. Added an `onClick` handler to the `.password-input-wrapper` container to forward focus to the inner password input, making the entire visual container interactive.
2. Updated the `.password-toggle-btn` to use a standard, static `aria-label="Toggle password visibility"` and `title="Toggle password visibility"` attribute. Added `aria-pressed={showPassword}` to properly indicate the active toggled state to screen readers instead of dynamically changing the label.

### 🎯 Why
- Users expect custom "input-like" containers (with borders and icons) to be fully interactive. Clicking anywhere inside the container should focus the input.
- Dynamically changing `aria-label` based on state is an anti-pattern for toggle buttons. Using a static label combined with `aria-pressed` provides a much clearer and standard experience for screen reader users.

### ♿ Accessibility
- Replaced dynamic `aria-label` with static `aria-label` + `aria-pressed`.

### 📸 Before/After
*(See attached video and screenshots generated during verification)*

---
*PR created automatically by Jules for task [18345086872220575089](https://jules.google.com/task/18345086872220575089) started by @DamienLove*