### PR TITLE
⚡ Bolt: Optimize combinedThreads useMemo to reduce memory allocations

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -4201,16 +4201,40 @@ function App() {
 
   const combinedThreads = useMemo(() => {
     if (lineInboxMode === 'PER_LINE') return [];
-    const lineFlattened = Object.values(lineThreads).flat();
 
-    // Create a Set of addresses present in the new line threads to filter out legacy duplicates
-    const lineAddresses = new Set(lineFlattened.map(t => t.address).filter(Boolean));
-    const uniqueLegacy = legacyThreads.filter(t => !t.address || !lineAddresses.has(t.address));
+    // ⚡ Bolt Performance Optimization: Replace chained array operations (.flat, .map, .filter, ...)
+    // with imperative single-pass loops to prevent intermediate array allocations and memory bloat.
+    const filtered = [];
+    const lineFiltered = [];
+    const lineAddresses = new Set();
 
-    const all = [...uniqueLegacy, ...lineFlattened];
+    const lineThreadValues = Object.values(lineThreads);
+    for (let i = 0; i < lineThreadValues.length; i++) {
+      const val = lineThreadValues[i];
+      // Account for non-array elements that .flat() would keep intact
+      const arr = Array.isArray(val) ? val : [val];
+      for (let j = 0; j < arr.length; j++) {
+        const t = arr[j];
+        if (!t) continue;
+        if (t.address) lineAddresses.add(t.address);
+        if (showArchived ? t.archived : !t.archived) {
+          lineFiltered.push(t);
+        }
+      }
+    }
 
-    // Filter by archive status
-    const filtered = all.filter(t => showArchived ? t.archived : !t.archived);
+    for (let i = 0; i < legacyThreads.length; i++) {
+      const t = legacyThreads[i];
+      if (!t) continue;
+      if (t.address && lineAddresses.has(t.address)) continue;
+      if (showArchived ? t.archived : !t.archived) {
+        filtered.push(t);
+      }
+    }
+
+    for (let i = 0; i < lineFiltered.length; i++) {
+      filtered.push(lineFiltered[i]);
+    }
 
     // Sort: Pinned first, then date
     return filtered.sort((a, b) => {


### PR DESCRIPTION
**💡 What:**
Replaced chained array operations (`.flat()`, `.map()`, `.filter()`) and spread syntax in the `combinedThreads` `useMemo` block within `web/src/App.jsx` with imperative single-pass loops. 

**🎯 Why:**
The `combinedThreads` computation happens frequently as threads update. Chaining array methods like `.flat()`, `.map()`, and `.filter()` alongside array spreading creates multiple intermediate, short-lived arrays. As the number of threads grows, this can lead to memory bloat and garbage collection pressure, causing slight stuttering or unresponsiveness. Moving to an imperative single-pass loop significantly reduces overhead.

**📊 Impact:**
Eliminates intermediate array allocations within the `useMemo` computation, reducing memory footprint and potentially lowering CPU overhead during re-renders, especially for accounts with a large number of `lineThreads` and `legacyThreads`. 

**🔬 Measurement:**
Code verification has shown that the logical output precisely matches the previous array manipulation chain. Local rendering tests confirm the UI remains stable, with playwright test passes verifying that the core structural functionality is maintained without breaking dependent behaviors.

---
*PR created automatically by Jules for task [16209945306574544414](https://jules.google.com/task/16209945306574544414) started by @DamienLove*