### PR TITLE
🎨 Palette: Improve password input accessibility and UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2024-04-08 - Accessible state toggle buttons and click-to-focus wrappers
+**Learning:** State toggle buttons (e.g. show/hide password) should use a static `aria-label` (like "Toggle password visibility") and dynamic `aria-pressed` or `aria-expanded` attributes, instead of mutating the `aria-label`. Additionally, input wrappers styled to look like larger inputs should forward clicks to focus the inner input, as users expect the entire visual field to be interactive.
+**Action:** Always verify state buttons use `aria-pressed` instead of changing their label, and ensure custom input wrappers have an `onClick` that forwards focus via `useRef`.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2522,6 +2522,7 @@ function App() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const passwordInputRef = useRef(null);
   const [authError, setAuthError] = useState('');
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [activePanel, setActivePanel] = useState('inbox');
@@ -4298,9 +4299,10 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordInputRef.current?.focus()}>
                   <input
                     id="login-password"
+                    ref={passwordInputRef}
                     className="login-input"
                     type={showPassword ? "text" : "password"}
                     value={password}
@@ -4311,8 +4313,12 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (

--- a/web/tests/login_ux.spec.js
+++ b/web/tests/login_ux.spec.js
@@ -11,17 +11,48 @@ test.describe('Login UX Improvements', () => {
     await expect(emailInput).toBeFocused();
   });
 
-  test('Password toggle button should have tooltip title', async ({ page }) => {
+  test('Password toggle button should have static aria-label and dynamic aria-pressed', async ({ page }) => {
     await page.goto('/');
 
     const toggleBtn = page.locator('.password-toggle-btn');
     await expect(toggleBtn).toBeVisible();
 
+    // Static aria-label
+    await expect(toggleBtn).toHaveAttribute('aria-label', 'Toggle password visibility');
+
     // Initially hidden (password type)
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
     await expect(toggleBtn).toHaveAttribute('title', 'Show password');
 
     // Click to show
     await toggleBtn.click();
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
     await expect(toggleBtn).toHaveAttribute('title', 'Hide password');
+  });
+
+  test('Clicking password wrapper should focus password input', async ({ page }) => {
+    await page.goto('/');
+
+    const wrapper = page.locator('.password-input-wrapper');
+    const input = page.locator('#login-password');
+    const toggleBtn = page.locator('.password-toggle-btn');
+
+    await expect(wrapper).toBeVisible();
+    await expect(input).toBeVisible();
+
+    // Click outside first
+    await page.locator('body').click();
+    await expect(input).not.toBeFocused();
+
+    // Click wrapper space
+    await wrapper.click();
+    await expect(input).toBeFocused();
+
+    // Click toggle button should not trigger focus on input (propagation stopped)
+    await input.blur();
+    await expect(input).not.toBeFocused();
+    await toggleBtn.click();
+    // After clicking toggle button, it should have focus or body, but not input
+    await expect(input).not.toBeFocused();
   });
 });


### PR DESCRIPTION
💡 What: Improved the accessibility and UX of the login screen password input.
🎯 Why: State toggle buttons should use static ARIA labels with `aria-pressed` states rather than mutating the label. Additionally, large custom input wrappers look interactive, so clicking empty space within the wrapper should forward focus to the actual input field.
📸 Before/After: Visuals remained identical, but interactive surface area is larger and screen-reader experience is corrected.
♿ Accessibility: Used `aria-pressed` for the toggle button and preserved keyboard accessibility by managing `e.stopPropagation()`.

---
*PR created automatically by Jules for task [6884469511842347359](https://jules.google.com/task/6884469511842347359) started by @DamienLove*