### PR TITLE
🛡️ Sentinel: [HIGH] Secure secrets management using defineSecret

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+
+## 2024-05-28 - [Insecure Secret Management via process.env]
+**Vulnerability:** API keys and sensitive credentials (like `EMAIL_USER`, `EMAIL_PASS`, `SPOTIFY_CLIENT_ID`) were being accessed directly via `process.env`. This is insecure because environment variables can be easily leaked in stack traces, diagnostic logs, or exposed during deployments.
+**Learning:** `process.env` does not provide access control or auditing for secrets. Cloud Functions should use the Secret Manager (via `defineSecret` from `firebase-functions/params`) to ensure that secrets are encrypted at rest, only accessible to authorized services, and decoupled from the application's configuration.
+**Prevention:** Always use `defineSecret` for sensitive keys. For v1 functions, use `.runWith({secrets: [secretName]})`. For v2 functions, pass `{secrets: [secretName]}` to the function options. Finally, lazily evaluate secrets via `.value()` inside the execution context instead of the module's top level.

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "pulselink-functions",
+  "name": "sotext-functions",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pulselink-functions",
+      "name": "sotext-functions",
       "dependencies": {
         "@genkit-ai/firebase": "latest",
         "@genkit-ai/vertexai": "latest",

--- a/functions/src/email.ts
+++ b/functions/src/email.ts
@@ -1,7 +1,11 @@
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
 import * as nodemailer from "nodemailer";
+import {defineSecret} from "firebase-functions/params";
 import {escapeHtml} from "./security";
+
+const emailUser = defineSecret("EMAIL_USER");
+const emailPass = defineSecret("EMAIL_PASS");
 
 // Ensure admin is initialized (handled in index.ts, but safe to check)
 if (admin.apps.length === 0) {
@@ -9,16 +13,17 @@ if (admin.apps.length === 0) {
 }
 const db = admin.firestore();
 
-const transporter = nodemailer.createTransport({
-  service: "gmail",
-  auth: {
-    user: process.env.EMAIL_USER,
-    pass: process.env.EMAIL_PASS,
-  },
-});
-
-export const sendEmailNotification = functions.https.onCall(
+export const sendEmailNotification = functions.runWith({
+  secrets: [emailUser, emailPass],
+}).https.onCall(
     async (data, context) => {
+      const transporter = nodemailer.createTransport({
+        service: "gmail",
+        auth: {
+          user: emailUser.value(),
+          pass: emailPass.value(),
+        },
+      });
       if (!context.auth) {
         throw new functions.https.HttpsError(
             "unauthenticated", "User must be authenticated");
@@ -93,7 +98,7 @@ export const sendEmailNotification = functions.https.onCall(
       }
 
       const mailOptions = {
-        from: `SoText <${process.env.EMAIL_USER}>`,
+        from: `SoText <${emailUser.value()}>`,
         to: email,
         subject: subject,
         text: text,

--- a/functions/src/spotify.ts
+++ b/functions/src/spotify.ts
@@ -1,18 +1,23 @@
 import {onCall, HttpsError} from "firebase-functions/v2/https";
 import {logger} from "firebase-functions";
+import {defineSecret} from "firebase-functions/params";
+
+const spotifyClientId = defineSecret("SPOTIFY_CLIENT_ID");
+const spotifyClientSecret = defineSecret("SPOTIFY_CLIENT_SECRET");
 
 const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
 
-export const getSpotifyAccessToken = onCall(async (request) => {
+export const getSpotifyAccessToken = onCall({
+  secrets: [spotifyClientId, spotifyClientSecret],
+}, async (request) => {
   // 1. Authenticate the user
   if (!request.auth) {
     throw new HttpsError("unauthenticated", "User must be authenticated.");
   }
 
-  // 2. Retrieve secrets (assumed to be in process.env for this environment)
-  // In production, use defineSecret() for better security, but process.env matches existing pattern (email.ts).
-  const clientId = process.env.SPOTIFY_CLIENT_ID;
-  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+  // 2. Retrieve secrets securely from Secret Manager
+  const clientId = spotifyClientId.value();
+  const clientSecret = spotifyClientSecret.value();
 
   if (!clientId || !clientSecret) {
     logger.error("Missing Spotify credentials in environment.");


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Environment variables (`EMAIL_USER`, `EMAIL_PASS`, `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`) were being accessed directly via `process.env`. This is insecure as environment variables can easily leak in diagnostic logs, stack traces, or external integrations.
🎯 Impact: An attacker or rogue dependency could exfiltrate plain-text credentials, leading to account compromise or service abuse (e.g. spam campaigns, resource exhaustion).
🔧 Fix: Migrated to Secret Manager via `defineSecret` from `firebase-functions/params`. For the v1 email function, applied `.runWith({secrets: [...]})` and lazily instantiated `nodemailer` within the request handler. For the v2 Spotify function, securely passed the configuration object with `{secrets: [...]}`. Added an entry to `.jules/sentinel.md` documenting this migration.
✅ Verification: Ran `tsc --noEmit` and reviewed logic locally. Checked code to assure `defineSecret.value()` is called within the functions' execution context.

---
*PR created automatically by Jules for task [8722403458425171151](https://jules.google.com/task/8722403458425171151) started by @DamienLove*