### PR TITLE
🎨 Palette: Add Empty State for Settings Search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2024-04-12 - Ensure existing imports when adding EmptyState
+**Learning:** When generating components like EmptyState or SearchIcon, verify they are imported and exist in the file scope to avoid application crashes.
+**Action:** Use grep to check for `<SearchIcon` and `<EmptyState` before adding instances of them to components.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -5391,9 +5391,23 @@ function App() {
                     return keywords.some(k => k.includes(term));
                   };
 
+                  const showAccount = show(['account', 'email', 'user id', 'password', 'reset', 'sign out', 'logout', 'profile']);
+                  const showWeb = show(['web', 'previews', 'scroll', 'auto-scroll', 'message previews', 'browser']);
+                  const showSoText = show(['sotext', 'remote', 'web access', 'contact info', 'extensions', '3rd party', 'time format', 'sync']);
+                  const showData = show(['data', 'delete', 'clear', 'cloud', 'account data', 'remove', 'privacy']);
+
                   return (
                     <>
-                      {show(['account', 'email', 'user id', 'password', 'reset', 'sign out', 'logout', 'profile']) && (
+                      {!showAccount && !showWeb && !showSoText && !showData && (
+                        <EmptyState
+                          icon={<SearchIcon />}
+                          title="No settings found"
+                          description={`We couldn't find any settings matching "${settingsSearch}"`}
+                          action={<button className="secondary-btn" onClick={() => setSettingsSearch('')}>Clear search</button>}
+                        />
+                      )}
+
+                      {showAccount && (
                         <div className="settings-card">
                           <h4>Account</h4>
                           <div className="settings-kv-row">
@@ -5414,7 +5428,7 @@ function App() {
                         </div>
                       )}
 
-                      {show(['web', 'previews', 'scroll', 'auto-scroll', 'message previews', 'browser']) && (
+                      {showWeb && (
                         <div className="settings-card">
                           <h4>Web preferences</h4>
                           <label className="settings-toggle">
@@ -5439,7 +5453,7 @@ function App() {
                         </div>
                       )}
 
-                      {show(['sotext', 'remote', 'web access', 'contact info', 'extensions', '3rd party', 'time format', 'sync']) && (
+                      {showSoText && (
                         <div className="settings-card">
                           <h4>SoText settings</h4>
                           <label className="settings-toggle">
@@ -5535,7 +5549,7 @@ function App() {
                         </div>
                       )}
 
-                      {show(['data', 'delete', 'clear', 'cloud', 'account data', 'remove', 'privacy']) && (
+                      {showData && (
                         <div className="settings-card">
                           <h4>Account data</h4>
                           <p className="settings-note">


### PR DESCRIPTION
💡 What: Added an `EmptyState` component when searching settings yields no matching sections.
🎯 Why: Searching for a non-existent setting previously resulted in a completely blank panel, making it feel like the application was broken.
📸 Before/After: A clear empty state with a "Clear search" button is now displayed instead of an empty view.
♿ Accessibility: Ensures that screen reader users and visual users have a clear indication that their search yielded no results rather than silently failing.

---
*PR created automatically by Jules for task [1331089020149012695](https://jules.google.com/task/1331089020149012695) started by @DamienLove*