### PR TITLE
🎨 Palette: [UX improvement] Enhance password toggle button accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+
+## 2026-04-15 - State Toggle Buttons
+**Learning:** Dynamic aria-labels on toggle buttons cause confusion for screen reader users as they constantly change. Static labels combined with state attributes convey the action and current state accurately.
+**Action:** Use a static `aria-label` alongside `aria-pressed` or `aria-expanded` for toggle buttons to indicate their active state.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -4312,7 +4312,8 @@ function App() {
                     type="button"
                     className="password-toggle-btn"
                     onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (

--- a/web/tests/login_ux.spec.js
+++ b/web/tests/login_ux.spec.js
@@ -11,17 +11,22 @@ test.describe('Login UX Improvements', () => {
     await expect(emailInput).toBeFocused();
   });
 
-  test('Password toggle button should have tooltip title', async ({ page }) => {
+  test('Password toggle button should have tooltip title and accessible state', async ({ page }) => {
     await page.goto('/');
 
     const toggleBtn = page.locator('.password-toggle-btn');
     await expect(toggleBtn).toBeVisible();
 
+    // Static accessible label
+    await expect(toggleBtn).toHaveAttribute('aria-label', 'Toggle password visibility');
+
     // Initially hidden (password type)
     await expect(toggleBtn).toHaveAttribute('title', 'Show password');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
 
     // Click to show
     await toggleBtn.click();
     await expect(toggleBtn).toHaveAttribute('title', 'Hide password');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
   });
 });


### PR DESCRIPTION
💡 What: Replaced the dynamically swapping `aria-label` on the login screen's password toggle button with a static label and `aria-pressed` attribute.
🎯 Why: Dynamic ARIA labels on state-toggling buttons can cause confusion for screen reader users as the label continuously changes. Using a static label combined with a state attribute (`aria-pressed` or `aria-expanded`) correctly conveys the element's purpose and its current state.
♿ Accessibility: Improves screen reader accessibility by following standard toggle button ARIA patterns.

---
*PR created automatically by Jules for task [9554592519478345449](https://jules.google.com/task/9554592519478345449) started by @DamienLove*