### PR TITLE
🎨 Palette: Improve password toggle accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+
+## 2024-04-16 - State Toggle Button Accessibility
+**Learning:** For state toggle buttons (e.g., 'Show/Hide Password'), dynamically changing the `aria-label` based on state can be confusing to screen readers as the label mutates upon interaction. It is better to use a static `aria-label` combined with `aria-pressed` or `aria-expanded` to represent the active state.
+**Action:** Next time I implement or fix a toggle button, I will use a static `aria-label` (like "Toggle password visibility") and dynamically set `aria-pressed={isToggled}` instead of swapping the label string.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -4312,7 +4312,8 @@ function App() {
                     type="button"
                     className="password-toggle-btn"
                     onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (

--- a/web/tests/login_ux.spec.js
+++ b/web/tests/login_ux.spec.js
@@ -11,17 +11,22 @@ test.describe('Login UX Improvements', () => {
     await expect(emailInput).toBeFocused();
   });
 
-  test('Password toggle button should have tooltip title', async ({ page }) => {
+  test('Password toggle button should have correct accessibility attributes and tooltip title', async ({ page }) => {
     await page.goto('/');
 
     const toggleBtn = page.locator('.password-toggle-btn');
     await expect(toggleBtn).toBeVisible();
 
+    // Static ARIA label
+    await expect(toggleBtn).toHaveAttribute('aria-label', 'Toggle password visibility');
+
     // Initially hidden (password type)
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
     await expect(toggleBtn).toHaveAttribute('title', 'Show password');
 
     // Click to show
     await toggleBtn.click();
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
     await expect(toggleBtn).toHaveAttribute('title', 'Hide password');
   });
 });


### PR DESCRIPTION
### 💡 What
Updated the password toggle button to use a static `aria-label` ("Toggle password visibility") and dynamically set the `aria-pressed` attribute, instead of swapping the `aria-label` string based on state. 

### 🎯 Why
Screen readers can get confused when the `aria-label` of a button mutates upon interaction. Using a static label with an `aria-pressed` (or `aria-expanded`) state correctly signals to the user that it is a toggleable button, and explicitly informs them of its current state without unexpectedly changing its fundamental identity.

### ♿ Accessibility
- Added static `aria-label="Toggle password visibility"` to the password toggle button.
- Added dynamic `aria-pressed={showPassword}` state.
- Maintained the existing `title` attribute for visual hover tooltips.

---
*PR created automatically by Jules for task [16201014027330081603](https://jules.google.com/task/16201014027330081603) started by @DamienLove*