### PR TITLE
🎨 Palette: Add interactive focus to password wrapper

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2026-04-17 - Make custom input wrappers focus the input field on click
+**Learning:** Users expect custom input wrappers with borders and icons to focus the nested input when clicked anywhere inside the container.
+**Action:** Always attach an onClick handler to the parent wrapper and use a ref to programmatically focus the underlying input field to expand the clickable area.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2522,6 +2522,7 @@ function App() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const passwordInputRef = useRef(null);
   const [authError, setAuthError] = useState('');
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [activePanel, setActivePanel] = useState('inbox');
@@ -4298,8 +4299,9 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordInputRef.current?.focus()}>
                   <input
+                    ref={passwordInputRef}
                     id="login-password"
                     className="login-input"
                     type={showPassword ? "text" : "password"}


### PR DESCRIPTION
💡 **What:** Added an `onClick` handler to the password input's wrapper container that programmatically focuses the inner input field.

🎯 **Why:** Custom input wrappers (like those with show/hide toggle icons) can feel unresponsive to mouse and touch users if clicking within the wrapper's boundaries doesn't focus the input. This micro-interaction expands the clickable hit area to the full container.

♿ **Accessibility:** This UX change makes selecting the field easier for mouse and mobile users without impacting keyboard tab navigation or screen reader behavior.

---
*PR created automatically by Jules for task [17745786481273322951](https://jules.google.com/task/17745786481273322951) started by @DamienLove*