### PR TITLE
⚡ Bolt: Prevent intermediate array allocations in thread sorting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2024-05-28 - Date Allocation in Render Loops
 **Learning:** `new Date()` allocation in hot render loops (like message lists) can be avoided by passing timestamps directly to `Intl.DateTimeFormat.format()`.
 **Action:** Always check if formatting functions accept primitives before wrapping them in objects inside `render` or `map`.
+## 2026-04-18 - Array Allocation in Render Loops
+**Learning:** Chained array methods like `.flat()`, `.map()`, and `.filter()` create intermediate array allocations that can impact performance when processing large arrays inside frequently re-evaluated `useMemo` blocks.
+**Action:** Replace chained array iterations with imperative single-pass `for...of` loops for large arrays inside `useMemo` blocks to prevent memory bloat and reduce garbage collection pressure.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -4201,19 +4201,39 @@ function App() {
 
   const combinedThreads = useMemo(() => {
     if (lineInboxMode === 'PER_LINE') return [];
-    const lineFlattened = Object.values(lineThreads).flat();
 
-    // Create a Set of addresses present in the new line threads to filter out legacy duplicates
-    const lineAddresses = new Set(lineFlattened.map(t => t.address).filter(Boolean));
-    const uniqueLegacy = legacyThreads.filter(t => !t.address || !lineAddresses.has(t.address));
+    const lineAddresses = new Set();
+    const all = [];
 
-    const all = [...uniqueLegacy, ...lineFlattened];
+    // Process line threads
+    for (const item of Object.values(lineThreads)) {
+      const items = Array.isArray(item) ? item : [item];
+      for (const t of items) {
+        if (!t) continue;
+        if (t.address) {
+          lineAddresses.add(t.address);
+        }
+        if (showArchived ? t.archived : !t.archived) {
+          all.push(t);
+        }
+      }
+    }
 
-    // Filter by archive status
-    const filtered = all.filter(t => showArchived ? t.archived : !t.archived);
+    // Process legacy threads
+    if (Array.isArray(legacyThreads)) {
+      for (const t of legacyThreads) {
+        if (!t) continue;
+        if (t.address && lineAddresses.has(t.address)) {
+          continue;
+        }
+        if (showArchived ? t.archived : !t.archived) {
+          all.push(t);
+        }
+      }
+    }
 
     // Sort: Pinned first, then date
-    return filtered.sort((a, b) => {
+    return all.sort((a, b) => {
       if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
       return (b.date ?? 0) - (a.date ?? 0);
     });


### PR DESCRIPTION
💡 What: Replaced the chained `.flat()`, `.map()`, `.filter()`, and array spreading inside the `combinedThreads` `useMemo` calculation in `web/src/App.jsx` with an imperative, single-pass `for...of` loop.
🎯 Why: In React, chaining multiple array methods creates hidden intermediate arrays on every iteration. For large inbox thread lists, this causes significant memory allocation and garbage collection pressure, especially when executing on every relevant state change inside `useMemo`.
📊 Impact: Eliminates 3 intermediate array allocations and a massive spread operation per render cycle, significantly reducing memory overhead and blocking time on the main thread for users with large inboxes.
🔬 Measurement: Verify by executing React DevTools profiler on the `combinedThreads` calculation when swapping inbox tabs or toggling the archive view with >1000 threads. The loop execution time should decrease noticeably.

---
*PR created automatically by Jules for task [9995688204719858585](https://jules.google.com/task/9995688204719858585) started by @DamienLove*