### PR TITLE
🎨 Palette: [UX improvement] Enhance password input wrapper interactivity and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2024-04-19 - Interactive Input Wrappers & Toggle Buttons
+**Learning:** When making an input wrapper interactive (like `onClick` to focus an inner input), inner state toggle buttons need `e.stopPropagation()` to avoid unintended focus side-effects. Also, state toggle buttons are more accessible with a static `aria-label` paired with an `aria-pressed` state, rather than dynamically changing the `aria-label` which can confuse screen readers.
+**Action:** Always add `e.stopPropagation()` to interactive inner elements of clickable wrappers. Use static `aria-label` + `aria-pressed`/`aria-expanded` for state toggles.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2564,6 +2564,7 @@ function App() {
   const contactSearchRef = useRef(null);
   const themeSearchRef = useRef(null);
   const messagesEndRef = useRef(null);
+  const passwordInputRef = useRef(null);
   const [premiumClaimActive, setPremiumClaimActive] = useState(false);
   const [proClaimActive, setProClaimActive] = useState(false);
 
@@ -4298,8 +4299,12 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div
+                  className="password-input-wrapper"
+                  onClick={() => passwordInputRef.current?.focus()}
+                >
                   <input
+                    ref={passwordInputRef}
                     id="login-password"
                     className="login-input"
                     type={showPassword ? "text" : "password"}
@@ -4311,8 +4316,12 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (

--- a/web/tests/login_ux.spec.js
+++ b/web/tests/login_ux.spec.js
@@ -11,17 +11,22 @@ test.describe('Login UX Improvements', () => {
     await expect(emailInput).toBeFocused();
   });
 
-  test('Password toggle button should have tooltip title', async ({ page }) => {
+  test('Password toggle button should have correct accessibility attributes and tooltip title', async ({ page }) => {
     await page.goto('/');
 
     const toggleBtn = page.locator('.password-toggle-btn');
     await expect(toggleBtn).toBeVisible();
 
+    // Static ARIA label
+    await expect(toggleBtn).toHaveAttribute('aria-label', 'Toggle password visibility');
+
     // Initially hidden (password type)
     await expect(toggleBtn).toHaveAttribute('title', 'Show password');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
 
     // Click to show
     await toggleBtn.click();
     await expect(toggleBtn).toHaveAttribute('title', 'Hide password');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
   });
 });


### PR DESCRIPTION
💡 **What:** Added an onClick handler to the `.password-input-wrapper` to forward focus to the inner password input, added `e.stopPropagation()` to the toggle button, and updated the toggle button's accessibility attributes to use a static `aria-label` with `aria-pressed`. Updated the relevant test.
🎯 **Why:** Users expect the entire input container to be interactive. Dynamically changing `aria-label` can confuse screen readers, whereas `aria-pressed` accurately conveys the state of the toggle button without altering the label.
📸 **Before/After:** (See frontend verification screenshots/videos in `/home/jules/verification/`)
♿ **Accessibility:** Replaced dynamic aria-label with a static "Toggle password visibility" and introduced `aria-pressed` state tracking.

---
*PR created automatically by Jules for task [2745036542907979073](https://jules.google.com/task/2745036542907979073) started by @DamienLove*