### PR TITLE
🎨 Palette: [UX improvement] Enhance password input UX and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,11 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+
+## 2026-04-21 - Focus Forwarding Pattern
+**Learning:** When making static wrapper elements interactive to forward focus to inner inputs, adding `role="presentation"` and using `useRef` instead of `getElementById` creates a robust and accessible UX enhancement without triggering strict linting rules like `jsx-a11y/no-static-element-interactions`.
+**Action:** Always use `useRef` for DOM access in React, add `role="presentation"` to interactive wrappers, and ensure inner interactive elements use `e.stopPropagation()`.
+
+## 2026-04-21 - Accessible Toggle Buttons
+**Learning:** State toggle buttons (like 'Show/Hide Password') should use a static `aria-label` (e.g., 'Toggle password visibility') combined with the `aria-pressed` or `aria-expanded` attribute, rather than dynamically changing the `aria-label` based on state. This provides better context to screen readers.
+**Action:** Use static ARIA labels and dynamic state attributes (`aria-pressed`, `aria-expanded`) for toggle controls.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2564,6 +2564,7 @@ function App() {
   const contactSearchRef = useRef(null);
   const themeSearchRef = useRef(null);
   const messagesEndRef = useRef(null);
+  const passwordInputRef = useRef(null);
   const [premiumClaimActive, setPremiumClaimActive] = useState(false);
   const [proClaimActive, setProClaimActive] = useState(false);
 
@@ -4298,8 +4299,13 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div
+                  className="password-input-wrapper"
+                  onClick={() => passwordInputRef.current?.focus()}
+                  role="presentation"
+                >
                   <input
+                    ref={passwordInputRef}
                     id="login-password"
                     className="login-input"
                     type={showPassword ? "text" : "password"}
@@ -4311,8 +4317,12 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (

--- a/web/tests/attachment_sending.spec.js
+++ b/web/tests/attachment_sending.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 import { test, expect } from '@playwright/test';
 
 test.use({

--- a/web/tests/custom_ux.spec.js
+++ b/web/tests/custom_ux.spec.js
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test('Focus forwarding for password input wrapper', async ({ page }) => {
+  await page.goto('/');
+
+  const passwordInput = page.locator('#login-password');
+  const container = page.locator('.password-input-wrapper');
+
+  await container.click({ position: { x: 5, y: 5 } });
+  await expect(passwordInput).toBeFocused();
+});

--- a/web/tests/password_toggle_accessibility.spec.js
+++ b/web/tests/password_toggle_accessibility.spec.js
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test('Password toggle button should have aria-pressed or aria-expanded', async ({ page }) => {
+  await page.goto('/');
+
+  const toggleBtn = page.locator('.password-toggle-btn');
+  await expect(toggleBtn).toBeVisible();
+
+  // Test the required accessibility attribute based on memory:
+  // "For accessibility, state toggle buttons (e.g., 'Show/Hide Password') should use a static aria-label (e.g., 'Toggle password visibility') combined with the aria-pressed or aria-expanded attribute to properly indicate their active toggled state to screen readers, rather than dynamically changing the aria-label based on state."
+
+  // Should have static aria-label
+  await expect(toggleBtn).toHaveAttribute('aria-label', 'Toggle password visibility');
+
+  // Should initially have aria-pressed="false"
+  await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
+
+  // Click to show password
+  await toggleBtn.click();
+
+  // Should now have aria-pressed="true"
+  await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
+});


### PR DESCRIPTION
💡 **What**: Improved the password input field's interaction and accessibility.
🎯 **Why**: Clicking the wrapper around the password input didn't focus the input field, which creates friction. Additionally, the toggle button dynamically changed its `aria-label`, which is an anti-pattern for screen readers; it should use a static label with an `aria-pressed` state.
♿ **Accessibility**: Added `role="presentation"` to the focus-forwarding wrapper and updated the "Show/Hide Password" button to use `aria-label="Toggle password visibility"` and `aria-pressed={showPassword}`.

---
*PR created automatically by Jules for task [5553303545092234194](https://jules.google.com/task/5553303545092234194) started by @DamienLove*