### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in account deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,7 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+## 2025-05-15 - Fix IDOR in account deletion
+**Vulnerability:** The account deletion function trusted the user-controllable `deviceId` field to delete device and beta agreement records, causing an Insecure Direct Object Reference (IDOR) where users could delete arbitrary device documents.
+**Learning:** Never trust client-provided or user-modifiable reference fields (like foreign keys in a user profile) when performing sensitive operations like document deletions. Always re-verify ownership or use a server-authoritative query.
+**Prevention:** Query for associated objects using a secure server-side filter (`where("uid", "==", context.auth.uid)`) instead of reading foreign keys from user profiles.

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -144,15 +144,11 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
 
   try {
     const userDocRef = db.collection("users").doc(uid);
-    const userSnap = await userDocRef.get();
-    const deviceId = userSnap.exists ?
-        (userSnap.data()?.deviceId as string | undefined) :
-        undefined;
 
     // Delete user profile + subcollections
     await db.recursiveDelete(userDocRef);
 
-    // Delete device registrations
+    // Delete device registrations and beta agreements securely
     const deviceDeletes: FirebaseFirestore.WriteBatch[] = [];
     let batch = db.batch();
     let ops = 0;
@@ -169,22 +165,26 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
     const deviceQuery = await db.collection("devices")
         .where("uid", "==", uid)
         .get();
-    deviceQuery.forEach((doc) => queueDelete(doc.ref));
-    if (deviceId) {
-      queueDelete(db.collection("devices").doc(deviceId));
-    }
+
+    // We collect device IDs to delete corresponding beta agreements securely
+    const ownedDeviceIds: string[] = [];
+
+    deviceQuery.forEach((doc) => {
+      queueDelete(doc.ref);
+      ownedDeviceIds.push(doc.id);
+    });
+
     if (ops > 0) deviceDeletes.push(batch);
     for (const b of deviceDeletes) {
       await b.commit();
     }
 
-    // Delete beta agreement tied to device ID (if present)
-    if (deviceId) {
-      await db.collection("betaAgreements")
-          .doc(deviceId)
-          .delete()
-          .catch(() => undefined);
-    }
+    // Delete beta agreements tied to owned device IDs
+    const betaDeletes = ownedDeviceIds.map((deviceId) =>
+      db.collection("betaAgreements").doc(deviceId).delete()
+          .catch(() => undefined),
+    );
+    await Promise.all(betaDeletes);
 
     // Delete link invites sent by or targeted to the user
     const inviteDeletes: Promise<FirebaseFirestore.WriteResult>[] = [];


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `deleteAccount` Cloud Function used the `deviceId` field directly from the user's profile document to delete associated documents in the `devices` and `betaAgreements` collections. Since users have write access to their own profile, a malicious actor could overwrite their `deviceId` with a victim's device ID and trigger an account deletion to wipe the victim's device records, causing severe Denial of Service (breaking the victim's alerts, syncing, etc.).
🎯 Impact: Arbitrary deletion of another user's device and beta agreement records, causing critical feature disruption for victims.
🔧 Fix: Removed trust in the `deviceId` profile field. Modified the logic to query the `devices` collection natively using the authenticated user's `uid`. Mapped the valid fetched device IDs to securely delete their corresponding beta agreements.
✅ Verification: Ran `npm run lint` and TypeScript compilation locally to confirm no regressions. Added the critical finding to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8667150607476196829](https://jules.google.com/task/8667150607476196829) started by @DamienLove*