### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in account deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,7 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+## 2024-05-24 - Account Deletion IDOR Vulnerability
+**Vulnerability:** IDOR in the account deletion function (`deleteAccount` in `functions/src/users.ts`) where the user's `deviceId` was extracted from the user's modifiable profile document and used to delete `betaAgreements` and device documents.
+**Learning:** This existed because the code implicitly trusted data stored within the user's profile document as a foreign key for other documents, ignoring that clients could potentially manipulate their profile document.
+**Prevention:** Perform sensitive operations by using server-authoritative queries matching the authenticated user's ID (`uid`) rather than relying on or trusting foreign keys stored within user-modifiable documents.

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -144,10 +144,6 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
 
   try {
     const userDocRef = db.collection("users").doc(uid);
-    const userSnap = await userDocRef.get();
-    const deviceId = userSnap.exists ?
-        (userSnap.data()?.deviceId as string | undefined) :
-        undefined;
 
     // Delete user profile + subcollections
     await db.recursiveDelete(userDocRef);
@@ -169,22 +165,26 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
     const deviceQuery = await db.collection("devices")
         .where("uid", "==", uid)
         .get();
-    deviceQuery.forEach((doc) => queueDelete(doc.ref));
-    if (deviceId) {
-      queueDelete(db.collection("devices").doc(deviceId));
-    }
+
+    const secureDeviceIds: string[] = [];
+    deviceQuery.forEach((doc) => {
+      secureDeviceIds.push(doc.id);
+      queueDelete(doc.ref);
+    });
+
     if (ops > 0) deviceDeletes.push(batch);
     for (const b of deviceDeletes) {
       await b.commit();
     }
 
-    // Delete beta agreement tied to device ID (if present)
-    if (deviceId) {
-      await db.collection("betaAgreements")
+    // Delete beta agreements tied to verified device IDs
+    const betaDeletes = secureDeviceIds.map((deviceId) =>
+      db.collection("betaAgreements")
           .doc(deviceId)
           .delete()
-          .catch(() => undefined);
-    }
+          .catch(() => undefined)
+    );
+    await Promise.all(betaDeletes);
 
     // Delete link invites sent by or targeted to the user
     const inviteDeletes: Promise<FirebaseFirestore.WriteResult>[] = [];


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** Insecure Direct Object Reference (IDOR) in `deleteAccount`. The user's `deviceId` was read from their modifiable profile document (`users/{uid}`) and implicitly trusted as a foreign key to delete records in the `devices` and `betaAgreements` collections.
**🎯 Impact:** A malicious user could update their profile's `deviceId` to target another user's device. When the attacker deletes their own account, the backend would erroneously delete the victim's device and beta agreement records, causing data loss and unlinking the victim's device.
**🔧 Fix:** The `deleteAccount` function no longer relies on the `deviceId` field in the user profile. Instead, it queries the `devices` collection using a secure filter (`where("uid", "==", uid)`). It gathers the verified device IDs from this query and uses them to securely delete the corresponding `betaAgreements` records.
**✅ Verification:** Compiled the Cloud Functions locally using `tsc`. Verified that the deletion loop now correctly processes `secureDeviceIds` derived from a server-authoritative query bound to the user's authenticated `uid`.

---
*PR created automatically by Jules for task [5122930621789513583](https://jules.google.com/task/5122930621789513583) started by @DamienLove*