### PR TITLE
🎨 Palette: Improve password toggle accessibility and UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+
+## 2025-05-16 - Static ARIA labels for toggles
+**Learning:** Dynamic aria-labels on state toggles (e.g. 'Show' vs 'Hide') can confuse screen readers by changing their identity.
+**Action:** Use a static aria-label (e.g., 'Toggle password visibility') combined with aria-pressed or aria-expanded to indicate active state.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2408,6 +2408,7 @@ function App() {
   const [showArchived, setShowArchived] = useState(false);
   const [messages, setMessages] = useState([]);
   const [isLoadingMessages, setIsLoadingMessages] = useState(false);
+  const passwordInputRef = useRef(null);
 
   // Fix: Use setUser to clear lint error or remove mock override if switching to real auth
   useEffect(() => {
@@ -4298,8 +4299,13 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div
+                  className="password-input-wrapper"
+                  onClick={() => passwordInputRef.current?.focus()}
+                  role="presentation"
+                >
                   <input
+                    ref={passwordInputRef}
                     id="login-password"
                     className="login-input"
                     type={showPassword ? "text" : "password"}
@@ -4311,8 +4317,12 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (


### PR DESCRIPTION
### 💡 What
- Made the `password-input-wrapper` container interactive by forwarding clicks directly to the nested `<input>`, making the entire box clickable.
- Updated the "Show/Hide Password" toggle button to use a static `aria-label` with an `aria-pressed` state, rather than dynamically changing the `aria-label`.
- Added `e.stopPropagation()` to the toggle button to ensure it doesn't trigger the parent container's focus handler.

### 🎯 Why
- **Interactive Container:** Users expect containers that look like inputs (with icons inside them) to act like inputs. Giving the wrapper an `onClick` that focuses the actual input reduces interaction friction.
- **Accessibility:** Dynamically changing the `aria-label` of a state toggle button (from "Show password" to "Hide password") can confuse screen readers by essentially changing the button's identity. Using a static label ("Toggle password visibility") paired with an `aria-pressed` or `aria-expanded` state is the recommended pattern.
- **Focus Control:** `e.stopPropagation()` ensures that interacting with the visibility toggle doesn't unintentionally steal focus away or cause jarring re-focuses.

### 📸 Before/After
- **Before:** Clicking the white space in the password field wrapper did nothing. Screen readers heard "Show password" then "Hide password" for the button.
- **After:** Clicking anywhere in the wrapper focuses the input. Screen readers hear "Toggle password visibility, unpressed" then "Toggle password visibility, pressed".

### ♿ Accessibility
- Improved screen reader experience for the password visibility toggle by implementing the standard static label + state pattern.
- Maintained strict accessibility by adding `role="presentation"` to the `<div>` used for the focus-forwarding click handler.

---
*PR created automatically by Jules for task [15544249261234530155](https://jules.google.com/task/15544249261234530155) started by @DamienLove*