### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in account deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+
+## 2024-06-15 - [IDOR in Account Deletion]
+**Vulnerability:** The account deletion function trusted the `deviceId` stored in the user's modifiable profile document as a foreign key to delete records in the `devices` and `betaAgreements` collections. An attacker could modify their `deviceId` to target and delete another user's device/agreement.
+**Learning:** Using user-modifiable fields as foreign keys for destructive operations creates an Insecure Direct Object Reference (IDOR) vulnerability. Backend logic must independently verify ownership.
+**Prevention:** Never trust client-provided or client-modifiable data for sensitive operations like deletion. Always query the database server-side using the authenticated user's ID (`context.auth.uid`) to discover authorized records before deleting them.

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "pulselink-functions",
+  "name": "sotext-functions",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pulselink-functions",
+      "name": "sotext-functions",
       "dependencies": {
         "@genkit-ai/firebase": "latest",
         "@genkit-ai/vertexai": "latest",

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -144,10 +144,6 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
 
   try {
     const userDocRef = db.collection("users").doc(uid);
-    const userSnap = await userDocRef.get();
-    const deviceId = userSnap.exists ?
-        (userSnap.data()?.deviceId as string | undefined) :
-        undefined;
 
     // Delete user profile + subcollections
     await db.recursiveDelete(userDocRef);
@@ -169,22 +165,26 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
     const deviceQuery = await db.collection("devices")
         .where("uid", "==", uid)
         .get();
-    deviceQuery.forEach((doc) => queueDelete(doc.ref));
-    if (deviceId) {
-      queueDelete(db.collection("devices").doc(deviceId));
-    }
+
+    const userDeviceIds: string[] = [];
+    deviceQuery.forEach((doc) => {
+      userDeviceIds.push(doc.id);
+      queueDelete(doc.ref);
+    });
+
     if (ops > 0) deviceDeletes.push(batch);
     for (const b of deviceDeletes) {
       await b.commit();
     }
 
-    // Delete beta agreement tied to device ID (if present)
-    if (deviceId) {
-      await db.collection("betaAgreements")
-          .doc(deviceId)
+    // Delete beta agreements tied to authorized device IDs
+    const betaAgreementDeletes = userDeviceIds.map((id) =>
+      db.collection("betaAgreements")
+          .doc(id)
           .delete()
-          .catch(() => undefined);
-    }
+          .catch(() => undefined),
+    );
+    await Promise.all(betaAgreementDeletes);
 
     // Delete link invites sent by or targeted to the user
     const inviteDeletes: Promise<FirebaseFirestore.WriteResult>[] = [];


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** Insecure Direct Object Reference (IDOR) in `deleteAccount` Cloud Function. The function used the `deviceId` stored in the user-modifiable profile document as a foreign key to identify and delete corresponding records in the `devices` and `betaAgreements` collections.
**Impact:** An attacker could modify their profile `deviceId` to target and delete any other user's active device registration and beta agreement. This causes an immediate Denial of Service for the victim's device (breaking push notifications, sync, and app access) and destroys their beta participation record.
**Fix:** Removed reliance on the profile document. The `deleteAccount` function now performs a secure, server-side query against the `devices` collection using `where("uid", "==", context.auth.uid)`. It extracts the legitimate `deviceId`s returned and securely uses them to process deletes.
**Verification:** Verified via TypeScript compilation that the new code paths correctly resolve and the types align. The `npm run test` local environment is currently broken (missing `jest` types in this specific directory state), but the code logic operates natively within Firestore semantics.

---
*PR created automatically by Jules for task [1602494222755621647](https://jules.google.com/task/1602494222755621647) started by @DamienLove*