### PR TITLE
🎨 Palette: Password visibility toggle accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+
+## 2024-05-24 - Password Toggle Button Accessibility
+**Learning:** For interactive state toggle buttons (like "Show/Hide Password"), changing the `aria-label` dynamically makes it harder for screen reader users to track the button's purpose and state.
+**Action:** Use a static descriptive `aria-label` (e.g., "Toggle password visibility") combined with `aria-pressed={state}` to correctly announce the button's active toggled state.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -4312,7 +4312,8 @@ function App() {
                     type="button"
                     className="password-toggle-btn"
                     onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (

--- a/web/tests/login_ux.spec.js
+++ b/web/tests/login_ux.spec.js
@@ -14,14 +14,16 @@ test.describe('Login UX Improvements', () => {
   test('Password toggle button should have tooltip title', async ({ page }) => {
     await page.goto('/');
 
-    const toggleBtn = page.locator('.password-toggle-btn');
+    const toggleBtn = page.getByRole('button', { name: 'Toggle password visibility' });
     await expect(toggleBtn).toBeVisible();
 
     // Initially hidden (password type)
     await expect(toggleBtn).toHaveAttribute('title', 'Show password');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
 
     // Click to show
     await toggleBtn.click();
     await expect(toggleBtn).toHaveAttribute('title', 'Hide password');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
   });
 });


### PR DESCRIPTION
**💡 What:**
Updated the password visibility toggle button in the login form to use a static `aria-label` ("Toggle password visibility") combined with the `aria-pressed` attribute, replacing the previous dynamic `aria-label`. The `title` attribute remains dynamic for visual tooltips. Updated the Playwright test to verify these new assertions.

**🎯 Why:**
Dynamically changing the `aria-label` of a toggle button makes it difficult for screen reader users to track its purpose and state. A static label with an `aria-pressed` attribute conforms to a11y best practices.

**📸 Before/After:**
The visual UI remains identical, but the underlying accessibility tree is improved.

**♿ Accessibility:**
- Added static `aria-label="Toggle password visibility"`
- Added `aria-pressed={showPassword}` to accurately announce the button's toggled state.

---
*PR created automatically by Jules for task [11124762488948576345](https://jules.google.com/task/11124762488948576345) started by @DamienLove*