### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in account deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,7 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+## 2026-04-29 - [IDOR in Account Deletion]
+**Vulnerability:** IDOR vulnerability where the `deleteAccount` function trusted the `deviceId` field from a user's modifiable profile document, potentially allowing a user to delete other users' `devices` and `betaAgreements` documents.
+**Learning:** Client-modifiable fields (like a profile document) cannot be trusted as references for sensitive operations (like cross-collection deletion) without authorization checks.
+**Prevention:** When performing sensitive operations based on relationships, always use server-authoritative queries mapped to the authenticated user's ID (e.g., `where("uid", "==", uid)`) rather than blindly trusting reference fields stored in modifiable documents.

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -144,10 +144,6 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
 
   try {
     const userDocRef = db.collection("users").doc(uid);
-    const userSnap = await userDocRef.get();
-    const deviceId = userSnap.exists ?
-        (userSnap.data()?.deviceId as string | undefined) :
-        undefined;
 
     // Delete user profile + subcollections
     await db.recursiveDelete(userDocRef);
@@ -166,25 +162,25 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
       }
     };
 
+    // Sentinel: Retrieve only server-authoritative device mappings
     const deviceQuery = await db.collection("devices")
         .where("uid", "==", uid)
         .get();
     deviceQuery.forEach((doc) => queueDelete(doc.ref));
-    if (deviceId) {
-      queueDelete(db.collection("devices").doc(deviceId));
-    }
+
     if (ops > 0) deviceDeletes.push(batch);
     for (const b of deviceDeletes) {
       await b.commit();
     }
 
-    // Delete beta agreement tied to device ID (if present)
-    if (deviceId) {
-      await db.collection("betaAgreements")
-          .doc(deviceId)
+    // Delete beta agreements tied to authorized device IDs
+    const betaAgreementDeletes = deviceQuery.docs.map((doc) => {
+      return db.collection("betaAgreements")
+          .doc(doc.id)
           .delete()
           .catch(() => undefined);
-    }
+    });
+    await Promise.all(betaAgreementDeletes);
 
     // Delete link invites sent by or targeted to the user
     const inviteDeletes: Promise<FirebaseFirestore.WriteResult>[] = [];


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: IDOR vulnerability in `deleteAccount` function. It relied on the `deviceId` reference field stored in the user's client-modifiable profile document (`users/{uid}`). A malicious user could alter this field in their profile to target and delete another user's `devices` and `betaAgreements` documents while deleting their own account.
🎯 **Impact**: Potential arbitrary document deletion of other users' device registrations and beta agreements (Data Loss/Denial of Service).
🔧 **Fix**: Removed reliance on the profile document entirely. The function now exclusively queries the `devices` collection via a server-authoritative query (`where("uid", "==", uid)`) to find all valid device mappings for the user, and securely uses those dynamically gathered document IDs to clean up both the `devices` and `betaAgreements` collections.
✅ **Verification**: 
1. Verified changes visually with `cat`.
2. Verified compilation works via `npx tsc --noEmit` in functions dir.
3. Added critical IDOR learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11136490001838118561](https://jules.google.com/task/11136490001838118561) started by @DamienLove*