### PR TITLE
⚡ Bolt: [performance] Eliminate intermediate array allocations in useMemo blocks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-28 - Date Allocation in Render Loops
 **Learning:** `new Date()` allocation in hot render loops (like message lists) can be avoided by passing timestamps directly to `Intl.DateTimeFormat.format()`.
 **Action:** Always check if formatting functions accept primitives before wrapping them in objects inside `render` or `map`.
+
+## 2024-05-30 - Flat() Edge Cases in Imperative Loops
+**Learning:** When converting `.flat()` operations to imperative loops for performance optimization, `.flat()` keeps non-array elements intact. Strict `Array.isArray()` checks without fallback will silently drop those items, causing data loss.
+**Action:** Always wrap elements using `Array.isArray(val) ? val : [val]` when replicating `.flat()` behavior in imperative loops to ensure non-array elements are preserved.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2088,9 +2088,16 @@ const Sidebar = memo(({
   const filteredThreads = useMemo(() => {
     const term = searchQuery.trim().toLowerCase();
     if (!term) return threads;
-    return getSearchIndex()
-      .filter(({ searchString }) => searchString.includes(term))
-      .map(({ thread }) => thread);
+
+    // Bolt: Use single-pass loop instead of chained .filter().map() to prevent intermediate array allocations
+    const result = [];
+    const index = getSearchIndex();
+    for (const item of index) {
+      if (item.searchString.includes(term)) {
+        result.push(item.thread);
+      }
+    }
+    return result;
   }, [getSearchIndex, searchQuery, threads]);
 
   const [collapsed, setCollapsed] = useState(false);
@@ -2771,9 +2778,16 @@ function App() {
   const filteredThemes = useMemo(() => {
     const term = themeSearch.trim().toLowerCase();
     if (!term) return publicThemes;
-    return getThemeSearchIndex()
-      .filter(({ searchString }) => searchString.includes(term))
-      .map(({ theme }) => theme);
+
+    // Bolt: Use single-pass loop instead of chained .filter().map() to prevent intermediate array allocations
+    const result = [];
+    const index = getThemeSearchIndex();
+    for (const item of index) {
+      if (item.searchString.includes(term)) {
+        result.push(item.theme);
+      }
+    }
+    return result;
   }, [getThemeSearchIndex, themeSearch, publicThemes]);
 
   const featuredThemeDocs = useMemo(() => {
@@ -2797,9 +2811,15 @@ function App() {
     if (!term) return deviceContacts;
 
     // Bolt: Use the pre-computed index for O(N) simple string inclusion check
-    return getContactSearchIndex()
-      .filter(({ searchString }) => searchString.includes(term))
-      .map(({ contact }) => contact);
+    // Use single-pass loop instead of chained .filter().map() to prevent intermediate array allocations
+    const result = [];
+    const index = getContactSearchIndex();
+    for (const item of index) {
+      if (item.searchString.includes(term)) {
+        result.push(item.contact);
+      }
+    }
+    return result;
   }, [getContactSearchIndex, contactSearch, deviceContacts]);
 
   // Bolt: Create a unified contact lookup map for avatars
@@ -4201,16 +4221,41 @@ function App() {
 
   const combinedThreads = useMemo(() => {
     if (lineInboxMode === 'PER_LINE') return [];
-    const lineFlattened = Object.values(lineThreads).flat();
 
-    // Create a Set of addresses present in the new line threads to filter out legacy duplicates
-    const lineAddresses = new Set(lineFlattened.map(t => t.address).filter(Boolean));
-    const uniqueLegacy = legacyThreads.filter(t => !t.address || !lineAddresses.has(t.address));
+    // Bolt: Prevent multiple intermediate arrays (.flat, .map, .filter, spreads) in hot path
+    const lineFlattened = [];
+    const lineAddresses = new Set();
 
-    const all = [...uniqueLegacy, ...lineFlattened];
+    // Safely replicate .flat() while collecting addresses
+    for (const lineArray of Object.values(lineThreads)) {
+      const items = Array.isArray(lineArray) ? lineArray : [lineArray];
+      for (const t of items) {
+        lineFlattened.push(t);
+        if (t.address) {
+          lineAddresses.add(t.address);
+        }
+      }
+    }
 
-    // Filter by archive status
-    const filtered = all.filter(t => showArchived ? t.archived : !t.archived);
+    const filtered = [];
+
+    // Process unique legacy threads and filter by archive status
+    for (const t of legacyThreads) {
+      if (!t.address || !lineAddresses.has(t.address)) {
+        const isArchived = Boolean(t.archived);
+        if (showArchived ? isArchived : !isArchived) {
+          filtered.push(t);
+        }
+      }
+    }
+
+    // Process line threads and filter by archive status
+    for (const t of lineFlattened) {
+      const isArchived = Boolean(t.archived);
+      if (showArchived ? isArchived : !isArchived) {
+        filtered.push(t);
+      }
+    }
 
     // Sort: Pinned first, then date
     return filtered.sort((a, b) => {


### PR DESCRIPTION
💡 What: Replaced chained array methods (`.filter().map()`, `.flat()`, spread syntax) in `useMemo` hooks with single-pass imperative loops inside `web/src/App.jsx`.
🎯 Why: Chained declarative array operations allocate multiple intermediate array objects under the hood. In heavily executed code paths like keystroke-dependent search hooks and render loops processing potentially long lists, these object creations and subsequent garbage collections block the main thread and impact UI snappiness.
📊 Impact: Completely eliminates intermediate array allocations and object spread allocations from `filteredThreads`, `filteredThemes`, `filteredDeviceContacts`, and `combinedThreads`, reducing garbage collection load during search typing and state updates.
🔬 Measurement: Run the application locally, search for a thread/theme/contact while profiling memory in DevTools—observe fewer intermediate array objects being allocated/GC'd during keystroke updates.

---
*PR created automatically by Jules for task [404557672374711959](https://jules.google.com/task/404557672374711959) started by @DamienLove*