### PR TITLE
🎨 Palette: Make password input wrapper focusable and improve a11y

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2562,6 +2562,7 @@ function App() {
   const [settingsSearch, setSettingsSearch] = useState('');
   const settingsSearchRef = useRef(null);
   const contactSearchRef = useRef(null);
+  const passwordInputRef = useRef(null);
   const themeSearchRef = useRef(null);
   const messagesEndRef = useRef(null);
   const [premiumClaimActive, setPremiumClaimActive] = useState(false);
@@ -4298,9 +4299,10 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordInputRef.current?.focus()} role="presentation">
                   <input
                     id="login-password"
+                    ref={passwordInputRef}
                     className="login-input"
                     type={showPassword ? "text" : "password"}
                     value={password}
@@ -4311,8 +4313,9 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => { e.stopPropagation(); setShowPassword(!showPassword); }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (

--- a/web/tests/visual.spec.js
+++ b/web/tests/visual.spec.js
@@ -12,11 +12,11 @@ test('visual verification of login page', async ({ page }) => {
   // Verify key elements are visible with correct classes
   await expect(page.locator('.login-card')).toBeVisible();
   await expect(page.locator('.brand-logo')).toBeVisible();
-  await expect(page.getByText('SoText Web')).toBeVisible();
+  await expect(page.getByText('sotext.app')).toBeVisible();
 
   // Verify Fonts are loaded (Inter and Space Grotesk)
   // This is a basic check to see if the computed style matches
-  const heading = page.getByRole('heading', { name: 'SoText Web' });
+  const heading = page.getByRole('heading', { name: 'sotext.app' });
   await expect(heading).toHaveCSS('font-family', /Space Grotesk/);
 
   const body = page.locator('body');


### PR DESCRIPTION
💡 What: 
- Made the password input wrapper clickable, automatically forwarding focus to the underlying input field.
- Updated the password toggle button to use a static `aria-label` combined with an `aria-pressed` state attribute.
- Fixed an outdated legacy string reference ('SoText Web' -> 'sotext.app') in `visual.spec.js` that was breaking Playwright visual testing.

🎯 Why: 
Users expect visual "container" elements surrounding inputs to be interactive. Requiring them to click precisely on the input text area itself causes friction. By delegating clicks from the wrapper to the input, the clickable area is significantly expanded, creating a smoother login experience. Additionally, updating the password toggle button to use `aria-pressed` is the modern, recommended accessibility standard for stateful toggle buttons.

📸 Before/After: 
Visually unchanged, but clicking anywhere inside the neon border of the password field now instantly focuses the input.

♿ Accessibility: 
- Added `role="presentation"` to the interactive wrapper to satisfy strict a11y linting rules (`jsx-a11y/no-static-element-interactions`) without confusing screen readers.
- Replaced dynamic `aria-label` ("Show password"/"Hide password") on the toggle button with a static `aria-label="Toggle password visibility"` and dynamic `aria-pressed={showPassword}`, ensuring screen readers correctly interpret the element as a stateful toggle button.

---
*PR created automatically by Jules for task [9380524169823994936](https://jules.google.com/task/9380524169823994936) started by @DamienLove*