### PR TITLE
🎨 Palette: Improve accessibility of state toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2025-05-15 - Accessible State Toggles
+**Learning:** Screen readers and tests expect state toggle buttons (like "Show/Hide Password" or "Expand/Collapse") to use a static `aria-label` or `title` combined with `aria-pressed` or `aria-expanded` to properly indicate active state, rather than dynamically changing the `aria-label` text based on state.
+**Action:** Always use static `aria-label` text with `aria-pressed` or `aria-expanded` attributes on toggle buttons instead of dynamic labels.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2111,8 +2111,9 @@ const Sidebar = memo(({
               <button
                 onClick={() => setShowArchived(!showArchived)}
                 className={`ghost-btn icon-only ${showArchived ? 'active' : ''}`}
-                title={showArchived ? "Show Inbox" : "Show Archive"}
-                aria-label={showArchived ? "Show Inbox" : "Show Archive"}
+                title="Toggle archive view"
+                aria-label="Toggle archive view"
+                aria-pressed={showArchived}
               >
                 {showArchived ? <InboxIcon /> : <ArchiveIcon />}
               </button>
@@ -2210,7 +2211,7 @@ const Sidebar = memo(({
       </div>
       <div className="sidebar-footer">
         {!collapsed && <button onClick={handleLogout} className="ghost-btn">Logout</button>}
-        <button onClick={() => setCollapsed(prev => !prev)} className="ghost-btn icon-only" title={collapsed ? "Expand" : "Collapse"} aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}>
+        <button onClick={() => setCollapsed(prev => !prev)} className="ghost-btn icon-only" title="Toggle sidebar" aria-label="Toggle sidebar" aria-expanded={!collapsed}>
           {collapsed ? (
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="13 17 18 12 13 7"></polyline><polyline points="6 17 11 12 6 7"></polyline></svg>
           ) : (
@@ -4312,8 +4313,9 @@ function App() {
                     type="button"
                     className="password-toggle-btn"
                     onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
-                    title={showPassword ? "Hide password" : "Show password"}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
+                    title="Toggle password visibility"
                   >
                     {showPassword ? (
                       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/web/tests/login_ux.spec.js
+++ b/web/tests/login_ux.spec.js
@@ -11,17 +11,23 @@ test.describe('Login UX Improvements', () => {
     await expect(emailInput).toBeFocused();
   });
 
-  test('Password toggle button should have tooltip title', async ({ page }) => {
+  test('Password toggle button should have static title and use aria-pressed', async ({ page }) => {
     await page.goto('/');
 
     const toggleBtn = page.locator('.password-toggle-btn');
     await expect(toggleBtn).toBeVisible();
 
-    // Initially hidden (password type)
-    await expect(toggleBtn).toHaveAttribute('title', 'Show password');
+    // The title should be static
+    await expect(toggleBtn).toHaveAttribute('title', 'Toggle password visibility');
+
+    // Initially hidden (password type), aria-pressed should be 'false' or omitted/falsy
+    // Playwright `toHaveAttribute` checks for exact match. Initially it's not toggled, so `aria-pressed="false"`.
+    // Let's verify aria-pressed behavior
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
 
     // Click to show
     await toggleBtn.click();
-    await expect(toggleBtn).toHaveAttribute('title', 'Hide password');
+    await expect(toggleBtn).toHaveAttribute('title', 'Toggle password visibility');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
   });
 });


### PR DESCRIPTION
💡 **What:** Replaced dynamic `aria-label` text with static descriptions and `aria-pressed`/`aria-expanded` attributes on state toggle buttons (password visibility, archive view, sidebar).

🎯 **Why:** Dynamically changing `aria-label` text on buttons that toggle states can be confusing for screen reader users, as the label changes upon interaction. Using static `aria-label` with `aria-pressed` or `aria-expanded` allows the screen reader to correctly announce the button's purpose and its current state.

📸 **Before/After:** Not a visual change, but a structural accessibility improvement. Visually verified the UI does not break.

♿ **Accessibility:** Fixes screen reader announcement of toggled states across the app. Updated the Playwright test `login_ux.spec.js` to ensure the new static title and `aria-pressed` values are correctly verified.

---
*PR created automatically by Jules for task [13930902654531243740](https://jules.google.com/task/13930902654531243740) started by @DamienLove*