### PR TITLE
🎨 Palette: Make password wrapper interactive and improve a11y

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2526,6 +2526,7 @@ function App() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const passwordInputRef = useRef(null);
   const [authError, setAuthError] = useState('');
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [activePanel, setActivePanel] = useState('inbox');
@@ -4313,9 +4314,10 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" role="presentation" onClick={() => passwordInputRef.current?.focus()}>
                   <input
                     id="login-password"
+                    ref={passwordInputRef}
                     className="login-input"
                     type={showPassword ? "text" : "password"}
                     value={password}
@@ -4326,8 +4328,12 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (

--- a/web/tests/login_ux.spec.js
+++ b/web/tests/login_ux.spec.js
@@ -11,17 +11,38 @@ test.describe('Login UX Improvements', () => {
     await expect(emailInput).toBeFocused();
   });
 
-  test('Password toggle button should have tooltip title', async ({ page }) => {
+  test('Password toggle button should have tooltip title and correct aria attributes', async ({ page }) => {
     await page.goto('/');
 
     const toggleBtn = page.locator('.password-toggle-btn');
     await expect(toggleBtn).toBeVisible();
 
+    // Check static aria-label
+    await expect(toggleBtn).toHaveAttribute('aria-label', 'Toggle password visibility');
+
     // Initially hidden (password type)
     await expect(toggleBtn).toHaveAttribute('title', 'Show password');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
 
     // Click to show
     await toggleBtn.click();
     await expect(toggleBtn).toHaveAttribute('title', 'Hide password');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('Clicking password wrapper should focus password input', async ({ page }) => {
+    await page.goto('/');
+
+    const wrapper = page.locator('.password-input-wrapper');
+    const input = page.locator('#login-password');
+
+    await expect(wrapper).toBeVisible();
+    await expect(input).toBeVisible();
+
+    // Click slightly to the left of the wrapper bounds, but inside the wrapper itself
+    // so we don't click on the input or the toggle button directly
+    await wrapper.click({ position: { x: 5, y: 5 } });
+
+    await expect(input).toBeFocused();
   });
 });


### PR DESCRIPTION
💡 What: Added click interaction to the password input wrapper to forward focus to the actual input field. Updated the password visibility toggle button to use a static `aria-label` with an `aria-pressed` state.
🎯 Why: Users expect input-like containers (with borders and inner icons) to be fully interactive. Clicking the container should focus the input.
♿ Accessibility: Improved screen reader experience by using `aria-pressed` for the toggle state instead of dynamically changing the `aria-label`, preventing screen reader confusion. Also added `role="presentation"` to the wrapper `div` to ensure it doesn't break semantic HTML expectations.

---
*PR created automatically by Jules for task [10491315156012216536](https://jules.google.com/task/10491315156012216536) started by @DamienLove*