### PR TITLE
🎨 Palette: Improve password field accessibility and focus UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2025-05-15 - Password Visibility Toggle Accessibility
+**Learning:** State toggle buttons (like "Show/Hide Password") should use a static `aria-label` combined with `aria-pressed` or `aria-expanded` to properly indicate their active toggled state to screen readers, rather than dynamically changing the `aria-label`.
+**Action:** Use `aria-pressed` or `aria-expanded` attributes on toggle buttons along with a static `aria-label` that describes the purpose of the button.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2526,6 +2526,7 @@ function App() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const passwordInputRef = useRef(null);
   const [authError, setAuthError] = useState('');
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [activePanel, setActivePanel] = useState('inbox');
@@ -4313,9 +4314,10 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordInputRef.current?.focus()} role="presentation">
                   <input
                     id="login-password"
+                    ref={passwordInputRef}
                     className="login-input"
                     type={showPassword ? "text" : "password"}
                     value={password}
@@ -4326,9 +4328,12 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
-                    title={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                   >
                     {showPassword ? (
                       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/web/tests/login_ux.spec.js
+++ b/web/tests/login_ux.spec.js
@@ -11,17 +11,18 @@ test.describe('Login UX Improvements', () => {
     await expect(emailInput).toBeFocused();
   });
 
-  test('Password toggle button should have tooltip title', async ({ page }) => {
+  test('Password toggle button should have proper aria attributes', async ({ page }) => {
     await page.goto('/');
 
     const toggleBtn = page.locator('.password-toggle-btn');
     await expect(toggleBtn).toBeVisible();
+    await expect(toggleBtn).toHaveAttribute('aria-label', 'Toggle password visibility');
 
     // Initially hidden (password type)
-    await expect(toggleBtn).toHaveAttribute('title', 'Show password');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
 
     // Click to show
     await toggleBtn.click();
-    await expect(toggleBtn).toHaveAttribute('title', 'Hide password');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
   });
 });


### PR DESCRIPTION
💡 **What:** 
- Made the `password-input-wrapper` clickable so it focuses the inner password input, providing a larger tap target.
- Added `role="presentation"` to the wrapper to comply with strict accessibility linters.
- Used `e.stopPropagation()` in the password visibility toggle button's click handler to prevent it from bubbling up and stealing focus from the input.
- Replaced dynamic `title` and `aria-label` attributes on the password toggle button with a static `aria-label` and an `aria-pressed` boolean attribute to properly convey the toggled state to screen readers.
- Updated Playwright tests to check for the new ARIA attributes.

🎯 **Why:** 
Users expect containers that visually look like inputs to act like inputs. If they click slightly off the actual `<input>` element but still inside the styled border, it should focus the input. For accessibility, state toggles like "Show/Hide Password" should maintain a static label explaining their purpose and use ARIA state attributes (`aria-pressed`) to convey their current status, rather than completely changing the label text dynamically.

♿ **Accessibility:**
- Improved screen reader experience for the password visibility toggle by using proper ARIA state attributes (`aria-pressed`).
- Prevented keyboard interaction confusion by explicitly hiding the focus wrapper from screen readers using `role="presentation"`.

---
*PR created automatically by Jules for task [17590288994588440695](https://jules.google.com/task/17590288994588440695) started by @DamienLove*