### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in deleteAccount

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+
+## 2024-05-03 - Insecure Direct Object Reference (IDOR) via Modifiable Profile Fields during Deletion
+**Vulnerability:** The `deleteAccount` Firebase Function extracted `deviceId` from the user's modifiable profile document (`users/{uid}`) to delete corresponding `devices` and `betaAgreements` documents. A malicious user could edit their profile to contain another user's `deviceId`, and then execute account deletion, leading to unauthorized destruction of another user's `betaAgreements` (IDOR).
+**Learning:** Never trust mutable user profile references (foreign keys/pointers) stored in a client-modifiable document when performing destructive operations. Security checks must be server-authoritative.
+**Prevention:** Rely strictly on server-side queries matching the authenticated user's ID (`uid`) against immutable fields on target documents (e.g., `where("uid", "==", context.auth.uid)`), completely bypassing modifiable references in user documents.

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -144,10 +144,6 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
 
   try {
     const userDocRef = db.collection("users").doc(uid);
-    const userSnap = await userDocRef.get();
-    const deviceId = userSnap.exists ?
-        (userSnap.data()?.deviceId as string | undefined) :
-        undefined;
 
     // Delete user profile + subcollections
     await db.recursiveDelete(userDocRef);
@@ -170,21 +166,20 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
         .where("uid", "==", uid)
         .get();
     deviceQuery.forEach((doc) => queueDelete(doc.ref));
-    if (deviceId) {
-      queueDelete(db.collection("devices").doc(deviceId));
-    }
     if (ops > 0) deviceDeletes.push(batch);
     for (const b of deviceDeletes) {
       await b.commit();
     }
 
-    // Delete beta agreement tied to device ID (if present)
-    if (deviceId) {
-      await db.collection("betaAgreements")
-          .doc(deviceId)
-          .delete()
-          .catch(() => undefined);
-    }
+    // Delete beta agreements tied to authorized device IDs
+    await Promise.all(
+        deviceQuery.docs.map((doc) =>
+          db.collection("betaAgreements")
+              .doc(doc.id)
+              .delete()
+              .catch(() => undefined),
+        ),
+    );
 
     // Delete link invites sent by or targeted to the user
     const inviteDeletes: Promise<FirebaseFirestore.WriteResult>[] = [];


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Insecure Direct Object Reference (IDOR) via Modifiable Profile Fields during Deletion. The `deleteAccount` function was extracting a `deviceId` from the user's modifiable profile document (`users/{uid}`) to delete `devices` and `betaAgreements` documents. A malicious user could alter their profile to inject another user's `deviceId` and execute account deletion, leading to unauthorized deletion of other users' documents.
🎯 **Impact:** Unauthorized data destruction and disruption of access for victims.
🔧 **Fix:** Refactored `deleteAccount` to rely entirely on a server-authoritative query to the `devices` collection, filtering by the authenticated user's `uid` (`where("uid", "==", context.auth.uid)`). This cleanly bypassed the vulnerable profile reference.
✅ **Verification:** Validated that the code compiles via `npx tsc --noEmit` and restored `package.json` lockfile artifacts generated during initial test exploration.

---
*PR created automatically by Jules for task [195610445988902665](https://jules.google.com/task/195610445988902665) started by @DamienLove*