### PR TITLE
⚡ Bolt: Prevent intermediate array allocations in useMemo hooks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2026-03-11 - Array Allocation in Render Loops (Revisited)
 **Learning:** Spread operators and `forEach` inside `useMemo` hooks (like `contactLookup` processing thousands of contacts) cause significant intermediate array allocations and garbage collection overhead, slowing down the main thread.
 **Action:** Replace array spreads and `forEach` loops with standard `for` loops in hot paths or large data derivations.
+## 2024-05-03 - Prevent array allocations in computationally heavy useMemo hooks
+**Learning:** Chained array methods (like `.flat()`, `.map()`, `.filter()`) and spread operators create intermediate arrays on every evaluation. In frequently executing `useMemo` hooks processing large lists (e.g., search filtering on keystrokes or combining complex thread state), these intermediate allocations cause unnecessary memory bloat and degrade performance.
+**Action:** Replace chained declarative array methods with single-pass imperative `for...of` loops within heavy `useMemo` blocks to perform the logic in a single pass without allocating temporary arrays. Always explicitly handle non-array elements when replacing `.flat()` to prevent data loss.

--- a/test_plan.md
+++ b/test_plan.md
@@ -1,0 +1,14 @@
+1. **Optimize search filtering useMemo hooks**
+   - Replace chained `.filter().map()` calls with single-pass `for...of` imperative loops in `filteredThreads`, `filteredThemes`, and `filteredDeviceContacts` in `web/src/App.jsx` to eliminate intermediate array allocations during frequent keystroke state changes.
+2. **Optimize combinedThreads useMemo hook**
+   - Replace the chained `.flat()`, `.map()`, `.filter()` and spread array allocations with an imperative loop in the `combinedThreads` hook in `web/src/App.jsx`.
+   - Explicitly handle non-array elements when replacing `.flat()` to prevent data loss.
+3. **Record Performance Learning**
+   - Append the learning regarding imperative loops preventing array allocations in computationally heavy/frequent `useMemo` hooks to `.jules/bolt.md`.
+4. **Verify Frontend Changes**
+   - Run `cd web && pnpm lint` to ensure no linting regressions.
+   - Run the local dev server and `cd web && npx playwright test` to verify no functionality is broken by the optimizations.
+5. **Pre-commit Steps**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+6. **Submit PR**
+   - Commit the changes and submit the PR on a new branch with a descriptive title format (`⚡ Bolt: [performance improvement]`).

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2103,9 +2103,13 @@ const Sidebar = memo(({
   const filteredThreads = useMemo(() => {
     const term = searchQuery.trim().toLowerCase();
     if (!term) return threads;
-    return getSearchIndex()
-      .filter(({ searchString }) => searchString.includes(term))
-      .map(({ thread }) => thread);
+    const result = [];
+    for (const item of getSearchIndex()) {
+      if (item.searchString.includes(term)) {
+        result.push(item.thread);
+      }
+    }
+    return result;
   }, [getSearchIndex, searchQuery, threads]);
 
   const [collapsed, setCollapsed] = useState(false);
@@ -2775,9 +2779,13 @@ function App() {
   const filteredThemes = useMemo(() => {
     const term = themeSearch.trim().toLowerCase();
     if (!term) return publicThemes;
-    return getThemeSearchIndex()
-      .filter(({ searchString }) => searchString.includes(term))
-      .map(({ theme }) => theme);
+    const result = [];
+    for (const item of getThemeSearchIndex()) {
+      if (item.searchString.includes(term)) {
+        result.push(item.theme);
+      }
+    }
+    return result;
   }, [getThemeSearchIndex, themeSearch, publicThemes]);
 
   const featuredThemeDocs = useMemo(() => {
@@ -2801,9 +2809,14 @@ function App() {
     if (!term) return deviceContacts;
 
     // Bolt: Use the pre-computed index for O(N) simple string inclusion check
-    return getContactSearchIndex()
-      .filter(({ searchString }) => searchString.includes(term))
-      .map(({ contact }) => contact);
+    // Bolt: Use single-pass imperative loop to avoid intermediate array allocation
+    const result = [];
+    for (const item of getContactSearchIndex()) {
+      if (item.searchString.includes(term)) {
+        result.push(item.contact);
+      }
+    }
+    return result;
   }, [getContactSearchIndex, contactSearch, deviceContacts]);
 
   // Bolt: Create a unified contact lookup map for avatars
@@ -4216,19 +4229,34 @@ function App() {
 
   const combinedThreads = useMemo(() => {
     if (lineInboxMode === 'PER_LINE') return [];
-    const lineFlattened = Object.values(lineThreads).flat();
 
-    // Create a Set of addresses present in the new line threads to filter out legacy duplicates
-    const lineAddresses = new Set(lineFlattened.map(t => t.address).filter(Boolean));
-    const uniqueLegacy = legacyThreads.filter(t => !t.address || !lineAddresses.has(t.address));
+    // Bolt: Use single-pass loops to prevent multiple large array allocations
+    const lineAddresses = new Set();
+    const all = [];
 
-    const all = [...uniqueLegacy, ...lineFlattened];
+    // Process line threads
+    for (const threadsArray of Object.values(lineThreads)) {
+      // Explicitly handle non-array elements as `.flat()` would
+      const arr = Array.isArray(threadsArray) ? threadsArray : [threadsArray];
+      for (const t of arr) {
+        if (t.address) {
+          lineAddresses.add(t.address);
+        }
+        if (showArchived ? t.archived : !t.archived) {
+          all.push(t);
+        }
+      }
+    }
 
-    // Filter by archive status
-    const filtered = all.filter(t => showArchived ? t.archived : !t.archived);
+    // Process legacy threads (filter out duplicates and by archive status)
+    for (const t of legacyThreads) {
+      if ((!t.address || !lineAddresses.has(t.address)) && (showArchived ? t.archived : !t.archived)) {
+        all.push(t);
+      }
+    }
 
     // Sort: Pinned first, then date
-    return filtered.sort((a, b) => {
+    return all.sort((a, b) => {
       if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
       return (b.date ?? 0) - (a.date ?? 0);
     });


### PR DESCRIPTION
**💡 What:** Replaced chained declarative array methods (`.filter().map()`, `.flat()`, etc.) and array spread operations with imperative `for...of` loops within several frequently executing `useMemo` hooks (`filteredThreads`, `filteredThemes`, `filteredDeviceContacts`, and `combinedThreads`) in `web/src/App.jsx`. Explicitly handled non-array elements when replacing `.flat()`.

**🎯 Why:** Chained array methods and spread operations create intermediate arrays on every evaluation. In frequently executing `useMemo` hooks that process large lists (e.g., search filtering firing on every keystroke, or combining complex thread state), these intermediate allocations cause unnecessary memory bloat and garbage collection overhead, which degrades rendering performance and blocks the main thread.

**📊 Impact:** Eliminates intermediate array allocations during frequent re-renders caused by search queries or thread state updates, reducing memory churn and improving main thread responsiveness.

**🔬 Measurement:** Verified via code inspection and by running the Playwright test suite to ensure no regressions in filtering or mapping logic.

---
*PR created automatically by Jules for task [7417730746567461778](https://jules.google.com/task/7417730746567461778) started by @DamienLove*