### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to email notification endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+
+## 2024-05-28 - Missing Rate Limiting on Email Notification
+**Vulnerability:** The `sendEmailNotification` Cloud Function lacked any rate limiting, allowing an authenticated attacker to abuse the endpoint to send an unlimited number of emails, potentially causing spam, reputation damage, and financial costs (via third-party email provider limits or charges).
+**Learning:** Even endpoints that seem innocuous (like sending a link request or a check-in message) can be abused if they trigger external actions (like sending an email). All endpoints that trigger external side-effects must have strict rate limits.
+**Prevention:** Always implement rate limiting on endpoints that trigger notifications (email, SMS, push) to prevent spam and abuse. Use Firestore-backed rate limiting or similar mechanisms to track usage per user over time.

--- a/functions/src/email.ts
+++ b/functions/src/email.ts
@@ -9,6 +9,36 @@ if (admin.apps.length === 0) {
 }
 const db = admin.firestore();
 
+// Sentinel: Rate limit check to prevent email spam abuse
+async function checkEmailRateLimit(uid: string): Promise<void> {
+  const MAX_EMAILS_PER_DAY = 50;
+  const now = admin.firestore.Timestamp.now();
+  const oneDayAgo = admin.firestore.Timestamp.fromMillis(
+      now.toMillis() - 24 * 60 * 60 * 1000,
+  );
+
+  const lookupsRef = db.collection("rate_limits")
+      .doc(uid)
+      .collection("emails");
+
+  const recentLookups = await lookupsRef
+      .where("timestamp", ">", oneDayAgo)
+      .count()
+      .get();
+
+  if (recentLookups.data().count >= MAX_EMAILS_PER_DAY) {
+    throw new functions.https.HttpsError(
+        "resource-exhausted",
+        "Daily email limit reached.",
+    );
+  }
+
+  // Log this lookup attempt
+  await lookupsRef.add({
+    timestamp: now,
+  });
+}
+
 const transporter = nodemailer.createTransport({
   service: "gmail",
   auth: {
@@ -26,6 +56,12 @@ export const sendEmailNotification = functions.https.onCall(
 
       const {email, messageType, payload} = data;
 
+      // Sentinel: Fetch verified user identity to prevent spoofing
+      const uid = context.auth.uid;
+
+      // Sentinel: Enforce rate limit for sending emails
+      await checkEmailRateLimit(uid);
+
       // Sentinel: Validate email format
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       if (!email || !emailRegex.test(email)) {
@@ -33,8 +69,6 @@ export const sendEmailNotification = functions.https.onCall(
             "invalid-argument", "Valid email is required");
       }
 
-      // Sentinel: Fetch verified user identity to prevent spoofing
-      const uid = context.auth.uid;
       let verifiedName = "SoText User";
 
       try {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `sendEmailNotification` cloud function lacked any rate limiting logic, allowing an authenticated user to abuse the endpoint and spam external email addresses.
🎯 **Impact:** This could lead to a severe spam vector, abuse of resources, potential blocklisting of the application's email domain, and financial costs if the email provider charges per sent email.
🔧 **Fix:** Implemented a new `checkEmailRateLimit` helper backed by Firestore to count the number of emails sent by a user in the last 24 hours. If the count exceeds 50, it throws an `HttpsError("resource-exhausted")`. Integrated this check securely before validating and processing the email request in `sendEmailNotification`.
✅ **Verification:** Verified via TypeScript compilation and code review that the fix correctly limits endpoint usage per user ID using robust `admin.firestore().collection(...).count()` aggregation.

---
*PR created automatically by Jules for task [5938980354620056874](https://jules.google.com/task/5938980354620056874) started by @DamienLove*