### PR TITLE
🎨 Palette: Improve password field interactivity and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2026-05-06 - State Toggle Button Accessibility
+**Learning:** State toggle buttons (like 'Show/Hide Password') should use a static `aria-label` (e.g., 'Toggle password visibility') and rely on `aria-pressed` or `aria-expanded` to convey their current state to screen readers. Dynamically changing the label based on state can be confusing.
+**Action:** Update the password toggle button to use a static label and `aria-pressed`.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -4313,7 +4313,7 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => document.getElementById('login-password')?.focus()} role="presentation">
                   <input
                     id="login-password"
                     className="login-input"
@@ -4326,8 +4326,9 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => { e.stopPropagation(); setShowPassword(!showPassword); }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (


### PR DESCRIPTION
**💡 What:** 
Added an `onClick` handler to the password input wrapper to forward focus to the inner input, making the entire container interactive. Updated the password toggle button to stop event propagation. Improved the password toggle button's accessibility by using a static `aria-label` and `aria-pressed` to indicate state.

**🎯 Why:** 
Users expect input-like containers (with borders and icons) to be fully clickable. If they click slightly off the inner text input but within the wrapper, it previously didn't focus, creating friction. 
For screen readers, dynamically changing the `aria-label` (from "Show password" to "Hide password") can be confusing or missed during rapid navigation. Using a standard toggle state (`aria-pressed`) on a static label is much more accessible.

**📸 Before/After:**
- Before: Clicking the space around the password field inside the wrapper did nothing.
- After: Clicking anywhere inside the wrapper properly focuses the inner input field.

**♿ Accessibility:**
- Added `role="presentation"` to the interactive wrapper.
- Changed the password toggle button to use `aria-label="Toggle password visibility"` with `aria-pressed={showPassword}` to properly announce the toggled state to screen readers instead of relying on dynamic label changes.

---
*PR created automatically by Jules for task [16676863259239710779](https://jules.google.com/task/16676863259239710779) started by @DamienLove*