### PR TITLE
🎨 Palette: Improve password input accessibility and UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2023-10-27 - Toggle Button Accessibility
+**Learning:** State toggle buttons (like "Show/Hide Password") shouldn't change their `aria-label` dynamically. This confuses screen readers.
+**Action:** Use a static `aria-label` (e.g., "Toggle password visibility") combined with the `aria-pressed` or `aria-expanded` attribute to indicate the current state.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2568,6 +2568,7 @@ function App() {
   const contactSearchRef = useRef(null);
   const themeSearchRef = useRef(null);
   const messagesEndRef = useRef(null);
+  const passwordInputRef = useRef(null);
   const [premiumClaimActive, setPremiumClaimActive] = useState(false);
   const [proClaimActive, setProClaimActive] = useState(false);
 
@@ -4313,8 +4314,9 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordInputRef.current?.focus()} role="presentation">
                   <input
+                    ref={passwordInputRef}
                     id="login-password"
                     className="login-input"
                     type={showPassword ? "text" : "password"}
@@ -4326,8 +4328,9 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => { e.stopPropagation(); setShowPassword(!showPassword); }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (

--- a/web/tests/login_ux.spec.js
+++ b/web/tests/login_ux.spec.js
@@ -11,7 +11,7 @@ test.describe('Login UX Improvements', () => {
     await expect(emailInput).toBeFocused();
   });
 
-  test('Password toggle button should have tooltip title', async ({ page }) => {
+  test('Password toggle button should have tooltip title and correct ARIA states', async ({ page }) => {
     await page.goto('/');
 
     const toggleBtn = page.locator('.password-toggle-btn');
@@ -19,9 +19,22 @@ test.describe('Login UX Improvements', () => {
 
     // Initially hidden (password type)
     await expect(toggleBtn).toHaveAttribute('title', 'Show password');
+    await expect(toggleBtn).toHaveAttribute('aria-label', 'Toggle password visibility');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
 
     // Click to show
     await toggleBtn.click();
     await expect(toggleBtn).toHaveAttribute('title', 'Hide password');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('Clicking password wrapper forwards focus to input', async ({ page }) => {
+    await page.goto('/');
+
+    const wrapper = page.locator('.password-input-wrapper');
+    const input = page.locator('#login-password');
+
+    await wrapper.click();
+    await expect(input).toBeFocused();
   });
 });


### PR DESCRIPTION
💡 **What**: Added `useRef` to allow clicking anywhere on the password input's `.password-input-wrapper` container to forward focus to the actual input field. Modernized the accessibility of the "Show/Hide Password" toggle button.
🎯 **Why**: Users expect "input-like" containers to be fully interactive. If they try to click near the border of the input field to type, the input needs to capture focus. Additionally, toggle buttons dynamically changing their `aria-label` is bad practice for screen readers; they should use static text alongside `aria-pressed`.
📸 **Before/After**: See attached Playwright verification screenshot.
♿ **Accessibility**: Replaced dynamic `aria-label` text on the toggle button with a static "Toggle password visibility" label alongside an `aria-pressed` state attribute, following standard accessibility patterns. Added `role="presentation"` to the wrapper div.

---
*PR created automatically by Jules for task [17090735421308475584](https://jules.google.com/task/17090735421308475584) started by @DamienLove*