### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in account deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+
+## 2024-05-28 - Insecure Direct Object Reference (IDOR) in Account Deletion
+**Vulnerability:** The `deleteAccount` Cloud Function used a client-modifiable field (`deviceId` from the user's profile document) to determine which associated device and beta agreement documents to delete. A malicious user could modify their own profile's `deviceId` to point to another user's device, causing the other user's device mappings and beta agreements to be deleted when the attacker deletes their own account.
+**Learning:** Foreign keys or reference fields stored within user-modifiable documents (like profiles) should never be trusted for destructive operations or access control decisions affecting other collections.
+**Prevention:** Always rely on server-authoritative queries matching the authenticated user's ID (e.g., `where("uid", "==", uid)`) against the target collection, rather than trusting reference fields in user-controlled documents.

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -144,10 +144,6 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
 
   try {
     const userDocRef = db.collection("users").doc(uid);
-    const userSnap = await userDocRef.get();
-    const deviceId = userSnap.exists ?
-        (userSnap.data()?.deviceId as string | undefined) :
-        undefined;
 
     // Delete user profile + subcollections
     await db.recursiveDelete(userDocRef);
@@ -166,25 +162,30 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
       }
     };
 
+    // Sentinel: Fix IDOR by querying authorized devices via uid, not trusting the user's modifiable profile.
     const deviceQuery = await db.collection("devices")
         .where("uid", "==", uid)
         .get();
-    deviceQuery.forEach((doc) => queueDelete(doc.ref));
-    if (deviceId) {
-      queueDelete(db.collection("devices").doc(deviceId));
-    }
+
+    const authorizedDeviceIds: string[] = [];
+    deviceQuery.forEach((doc) => {
+      queueDelete(doc.ref);
+      authorizedDeviceIds.push(doc.id);
+    });
+
     if (ops > 0) deviceDeletes.push(batch);
     for (const b of deviceDeletes) {
       await b.commit();
     }
 
-    // Delete beta agreement tied to device ID (if present)
-    if (deviceId) {
-      await db.collection("betaAgreements")
-          .doc(deviceId)
+    // Delete beta agreements tied to authorized device IDs
+    const betaAgreementDeletes = authorizedDeviceIds.map((id) =>
+      db.collection("betaAgreements")
+          .doc(id)
           .delete()
-          .catch(() => undefined);
-    }
+          .catch(() => undefined)
+    );
+    await Promise.all(betaAgreementDeletes);
 
     // Delete link invites sent by or targeted to the user
     const inviteDeletes: Promise<FirebaseFirestore.WriteResult>[] = [];


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** Insecure Direct Object Reference (IDOR) in `deleteAccount` where a user-provided `deviceId` from their profile was used to delete associated device mappings and beta agreements without validating ownership.
**Impact:** A malicious user could modify their profile's `deviceId` field to point to another user's active device, causing the other user's device mappings to be deleted when the attacker deletes their account.
**Fix:** Removed reliance on the user-modifiable profile field. The function now securely queries the `devices` collection by the authenticated user's `uid` to discover all authorized devices, deleting only those.
**Verification:** Validated that the code uses server-authoritative queries (`where("uid", "==", uid)`), compiles successfully (`npx tsc --noEmit`), and passes tests.

---
*PR created automatically by Jules for task [14549827374834494693](https://jules.google.com/task/14549827374834494693) started by @DamienLove*