### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in account deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,7 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+## 2026-05-09 - Fix IDOR in account deletion
+**Vulnerability:** deleteAccount relied on a user-modifiable deviceId field to delete cross-collection documents (betaAgreements), allowing arbitrary document deletion.
+**Learning:** Relying on client-provided or modifiable foreign keys for destructive operations creates Insecure Direct Object Reference vulnerabilities.
+**Prevention:** Always perform server-authoritative queries using the authenticated user's ID to fetch and delete associated foreign records.

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "pulselink-functions",
+  "name": "sotext-functions",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pulselink-functions",
+      "name": "sotext-functions",
       "dependencies": {
         "@genkit-ai/firebase": "latest",
         "@genkit-ai/vertexai": "latest",

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -144,10 +144,6 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
 
   try {
     const userDocRef = db.collection("users").doc(uid);
-    const userSnap = await userDocRef.get();
-    const deviceId = userSnap.exists ?
-        (userSnap.data()?.deviceId as string | undefined) :
-        undefined;
 
     // Delete user profile + subcollections
     await db.recursiveDelete(userDocRef);
@@ -169,22 +165,23 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
     const deviceQuery = await db.collection("devices")
         .where("uid", "==", uid)
         .get();
-    deviceQuery.forEach((doc) => queueDelete(doc.ref));
-    if (deviceId) {
-      queueDelete(db.collection("devices").doc(deviceId));
-    }
+
+    const authorizedDeviceIds: string[] = [];
+    deviceQuery.forEach((doc) => {
+      queueDelete(doc.ref);
+      authorizedDeviceIds.push(doc.id);
+    });
+
     if (ops > 0) deviceDeletes.push(batch);
     for (const b of deviceDeletes) {
       await b.commit();
     }
 
-    // Delete beta agreement tied to device ID (if present)
-    if (deviceId) {
-      await db.collection("betaAgreements")
-          .doc(deviceId)
-          .delete()
-          .catch(() => undefined);
-    }
+    // Delete beta agreements securely using authorized device IDs
+    const betaAgreementDeletes = authorizedDeviceIds.map((id) =>
+      db.collection("betaAgreements").doc(id).delete().catch(() => undefined)
+    );
+    await Promise.all(betaAgreementDeletes);
 
     // Delete link invites sent by or targeted to the user
     const inviteDeletes: Promise<FirebaseFirestore.WriteResult>[] = [];


### PR DESCRIPTION
**🚨 Severity:** CRITICAL

**💡 Vulnerability:** The `deleteAccount` Cloud Function in `functions/src/users.ts` relied on a user-modifiable `deviceId` field located in the `users/{uid}` document to determine which `betaAgreements` and `devices` documents to delete. This allowed an attacker to change their `deviceId` to point to another user's device and delete cross-collection documents (an IDOR vulnerability).

**🎯 Impact:** A malicious user could arbitrarily delete beta agreements or device registrations belonging to other users, potentially disrupting their access or invalidating their agreements.

**🔧 Fix:** Modified the deletion logic to completely ignore the client-modifiable `deviceId` field in the user profile. Instead, the function now relies on a server-authoritative query (`where("uid", "==", uid)`) against the `devices` collection to safely gather all authorized device IDs owned by the authenticated user, and uses this secure array to process the `betaAgreements` deletions.

**✅ Verification:**
- Ensured TypeScript compilation succeeds via `npx tsc --noEmit`.
- Validated via static analysis that `db.collection("betaAgreements").doc(id).delete()` is only called on IDs securely fetched from the `devices` query bounded by the authenticated user's `uid`.

---
*PR created automatically by Jules for task [13826825286307338427](https://jules.google.com/task/13826825286307338427) started by @DamienLove*