### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in account deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+
+## 2024-05-28 - Insecure Direct Object Reference (IDOR) in Account Deletion
+**Vulnerability:** The `deleteAccount` Cloud Function used a user-provided `deviceId` stored within their modifiable user profile to delete associated entries in the `devices` and `betaAgreements` collections. A malicious user could alter their profile's `deviceId` to that of another user, causing the backend to delete the victim's device registration and beta agreement during account deletion.
+**Learning:** Never trust referential data or foreign keys stored within user-modifiable documents for sensitive operations (like deletions or privilege elevation) without secondary verification.
+**Prevention:** Always rely on server-authoritative queries for data associations when performing sensitive actions. In this case, querying the `devices` collection by the authenticated user's ID (`where("uid", "==", uid)`) ensures only devices verifiably owned by the user are affected.

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "pulselink-functions",
+  "name": "sotext-functions",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pulselink-functions",
+      "name": "sotext-functions",
       "dependencies": {
         "@genkit-ai/firebase": "latest",
         "@genkit-ai/vertexai": "latest",

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -144,13 +144,20 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
 
   try {
     const userDocRef = db.collection("users").doc(uid);
-    const userSnap = await userDocRef.get();
-    const deviceId = userSnap.exists ?
-        (userSnap.data()?.deviceId as string | undefined) :
-        undefined;
+
+    // We do NOT trust the deviceId stored on the user document for deletions,
+    // as it can be modified by the user to perform an IDOR attack against
+    // other users' devices and betaAgreements.
+    // Instead, we rely solely on server-authoritative queries.
 
     // Delete user profile + subcollections
     await db.recursiveDelete(userDocRef);
+
+    // Get all devices owned by the user (Server Authoritative)
+    const deviceQuery = await db.collection("devices")
+        .where("uid", "==", uid)
+        .get();
+    const authorizedDeviceIds: string[] = [];
 
     // Delete device registrations
     const deviceDeletes: FirebaseFirestore.WriteBatch[] = [];
@@ -166,22 +173,20 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
       }
     };
 
-    const deviceQuery = await db.collection("devices")
-        .where("uid", "==", uid)
-        .get();
-    deviceQuery.forEach((doc) => queueDelete(doc.ref));
-    if (deviceId) {
-      queueDelete(db.collection("devices").doc(deviceId));
-    }
+    deviceQuery.forEach((doc) => {
+      authorizedDeviceIds.push(doc.id);
+      queueDelete(doc.ref);
+    });
+
     if (ops > 0) deviceDeletes.push(batch);
     for (const b of deviceDeletes) {
       await b.commit();
     }
 
-    // Delete beta agreement tied to device ID (if present)
-    if (deviceId) {
+    // Delete beta agreements tied to authorized device IDs
+    for (const id of authorizedDeviceIds) {
       await db.collection("betaAgreements")
-          .doc(deviceId)
+          .doc(id)
           .delete()
           .catch(() => undefined);
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Insecure Direct Object Reference (IDOR) in the `deleteAccount` Cloud Function. The function was relying on a user-provided `deviceId` stored within their modifiable user profile to delete associated entries in the `devices` and `betaAgreements` collections. A malicious user could alter their profile's `deviceId` to that of another user, causing the backend to delete the victim's device registration and beta agreement during account deletion.
🎯 Impact: A malicious user could indiscriminately delete other users' active device registrations and signed beta agreements, causing loss of service and data for innocent users.
🔧 Fix: Removed reliance on the user profile's `deviceId`. The deletion logic now relies solely on a server-authoritative query of the `devices` collection (`where("uid", "==", uid)`) to find and securely delete only the devices verifiably owned by the authenticated user, completely mitigating the IDOR vector.
✅ Verification: Ensure the function continues to compile (`cd functions && npm run build`). 

Also added a journal entry in `.jules/sentinel.md` documenting the vulnerability and prevention pattern.

---
*PR created automatically by Jules for task [2297913594710034514](https://jules.google.com/task/2297913594710034514) started by @DamienLove*