### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in account deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+
+## 2026-05-13 - Fix IDOR in account deletion
+**Vulnerability:** Trusting modifiable user profile data (deviceId) to delete resources (devices, betaAgreements).
+**Learning:** Users can modify their profile data to delete other users' resources (IDOR). Authoritative lookups must rely on trusted server-side queries (where uid == auth.uid).
+**Prevention:** Rely on server-side queries matching the authenticated user's ID for sensitive deletions, rather than trusting foreign keys stored in user-modifiable documents.

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -144,10 +144,6 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
 
   try {
     const userDocRef = db.collection("users").doc(uid);
-    const userSnap = await userDocRef.get();
-    const deviceId = userSnap.exists ?
-        (userSnap.data()?.deviceId as string | undefined) :
-        undefined;
 
     // Delete user profile + subcollections
     await db.recursiveDelete(userDocRef);
@@ -169,19 +165,22 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
     const deviceQuery = await db.collection("devices")
         .where("uid", "==", uid)
         .get();
-    deviceQuery.forEach((doc) => queueDelete(doc.ref));
-    if (deviceId) {
-      queueDelete(db.collection("devices").doc(deviceId));
-    }
+
+    const authorizedDeviceIds: string[] = [];
+    deviceQuery.forEach((doc) => {
+      queueDelete(doc.ref);
+      authorizedDeviceIds.push(doc.id);
+    });
+
     if (ops > 0) deviceDeletes.push(batch);
     for (const b of deviceDeletes) {
       await b.commit();
     }
 
-    // Delete beta agreement tied to device ID (if present)
-    if (deviceId) {
+    // Delete beta agreements securely tied to authorized device IDs
+    for (const authDeviceId of authorizedDeviceIds) {
       await db.collection("betaAgreements")
-          .doc(deviceId)
+          .doc(authDeviceId)
           .delete()
           .catch(() => undefined);
     }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Insecure Direct Object Reference (IDOR) during account deletion. The `deleteAccount` function relied on the `deviceId` field in the user's modifiable profile document (`users/{uid}`) to identify and delete corresponding `betaAgreements` documents. Since users could update their own profile document, an attacker could potentially modify their `deviceId` to target and delete another user's beta agreement during account deletion.
🎯 **Impact:** An attacker could delete other users' `betaAgreements` and potentially unlink devices, causing disruption of service or loss of access for targeted users.
🔧 **Fix:** Refactored `deleteAccount` to rely exclusively on server-authoritative queries. Instead of reading `deviceId` from the user profile, the function now securely queries the `devices` collection for all devices explicitly owned by the user (`where("uid", "==", uid)`), and then uses the resulting list of authorized device IDs to safely delete the corresponding `betaAgreements`.
✅ **Verification:** Verified that `functions` compile via `pnpm run build` and `pnpm run test` executes successfully. The changes have been audited in `src/users.ts`.

---
*PR created automatically by Jules for task [15563987672861997264](https://jules.google.com/task/15563987672861997264) started by @DamienLove*