### PR TITLE
🎨 Palette: Make password input wrapper interactive

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2026-05-13 - Inner Interactive Elements in Input Wrappers
+**Learning:** When making an input wrapper interactive via an onClick handler to forward focus, inner interactive elements (like state toggle buttons) must use e.stopPropagation() to prevent unintended focus side effects.
+**Action:** Always use e.stopPropagation() in onClick handlers of inner interactive elements when the parent wrapper is designed to forward focus.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2526,6 +2526,7 @@ function App() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const passwordInputRef = useRef(null);
   const [authError, setAuthError] = useState('');
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [activePanel, setActivePanel] = useState('inbox');
@@ -4313,8 +4314,9 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordInputRef.current?.focus()} role="presentation">
                   <input
+                    ref={passwordInputRef}
                     id="login-password"
                     className="login-input"
                     type={showPassword ? "text" : "password"}
@@ -4326,7 +4328,7 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
+                    onClick={(e) => { e.stopPropagation(); setShowPassword(!showPassword); }}
                     aria-label={showPassword ? "Hide password" : "Show password"}
                     title={showPassword ? "Hide password" : "Show password"}
                   >


### PR DESCRIPTION
💡 **What:** Made the password input's wrapper container (`.password-input-wrapper`) clickable so that it forwards focus directly to the underlying password input field.

🎯 **Why:** Users intuitively expect input-like containers (with borders and icons) to be fully interactive. Expanding the hit area reduces friction, particularly when clicking near the edge of the input. 

📸 **Before/After:** No visual changes. This is a purely interaction/UX enhancement.

♿ **Accessibility:** Added `role="presentation"` to the wrapper `div` to ensure screen readers don't misinterpret the clickable `div` (since keyboard users will naturally tab directly to the `input`). Added `e.stopPropagation()` to the "show/hide" toggle button so that clicking it doesn't trigger the wrapper's focus logic and disrupt the user's flow.

---
*PR created automatically by Jules for task [8460678186629552592](https://jules.google.com/task/8460678186629552592) started by @DamienLove*