### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in account deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,7 @@
 **Vulnerability:** While theme submissions were validated for XSS vectors (like `javascript:` URLs) by a backend Cloud Function, user profile updates (avatar, theme preferences) were written directly to Firestore via `public_profiles` without content validation in `firestore.rules`.
 **Learning:** Backend validation (Cloud Functions triggers) only protects data flowing through that specific pipeline (e.g., submission queues). It does not protect direct database writes allowed by security rules. Security must be enforced at the entry point (Firestore Rules) for direct writes.
 **Prevention:** Implement validation functions (e.g., `isValidImageUrl`) directly in `firestore.rules` and enforce them on all fields that accept URLs or sensitive content in `create` and `update` operations.
+## 2026-05-14 - [IDOR in Account Deletion]
+**Vulnerability:** IDOR in the deleteAccount function, because deviceId was read from the user's document directly.
+**Learning:** User modifiable documents should never be trusted as the authoritative source for ID-to-resource associations, especially for deletion.
+**Prevention:** Always rely on server-authoritative queries linked directly to the authenticated user's uid.

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -144,15 +144,15 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
 
   try {
     const userDocRef = db.collection("users").doc(uid);
-    const userSnap = await userDocRef.get();
-    const deviceId = userSnap.exists ?
-        (userSnap.data()?.deviceId as string | undefined) :
-        undefined;
 
     // Delete user profile + subcollections
     await db.recursiveDelete(userDocRef);
 
-    // Delete device registrations
+    // Delete device registrations and beta agreements based on auth
+    const deviceQuery = await db.collection("devices")
+        .where("uid", "==", uid)
+        .get();
+
     const deviceDeletes: FirebaseFirestore.WriteBatch[] = [];
     let batch = db.batch();
     let ops = 0;
@@ -166,24 +166,16 @@ export const deleteAccount = functions.https.onCall(async (_data, context) => {
       }
     };
 
-    const deviceQuery = await db.collection("devices")
-        .where("uid", "==", uid)
-        .get();
-    deviceQuery.forEach((doc) => queueDelete(doc.ref));
-    if (deviceId) {
-      queueDelete(db.collection("devices").doc(deviceId));
-    }
+    deviceQuery.forEach((doc) => {
+      // Delete the device mapping
+      queueDelete(doc.ref);
+      // Delete the corresponding betaAgreement
+      queueDelete(db.collection("betaAgreements").doc(doc.id));
+    });
+
     if (ops > 0) deviceDeletes.push(batch);
     for (const b of deviceDeletes) {
       await b.commit();
-    }
-
-    // Delete beta agreement tied to device ID (if present)
-    if (deviceId) {
-      await db.collection("betaAgreements")
-          .doc(deviceId)
-          .delete()
-          .catch(() => undefined);
     }
 
     // Delete link invites sent by or targeted to the user


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Insecure Direct Object Reference (IDOR) / Authorization Bypass in `functions/src/users.ts`.
🎯 **Impact:** An attacker could modify their user document's `deviceId` field to match a victim's `deviceId`. When the attacker calls `deleteAccount`, it deletes their own user record but maliciously deletes the victim's device mapping and `betaAgreement` documents from Firestore.
🔧 **Fix:** Refactored `deleteAccount` to stop trusting the `deviceId` present on the user's profile document. Instead, it relies on a server-authoritative query (`db.collection("devices").where("uid", "==", uid)`) to find only the device records that genuinely belong to the authenticated user and deletes the associated `betaAgreements` using those verified IDs. Unnecessary dependency changes and lockfiles generated during testing have also been reverted.
✅ **Verification:** The TypeScript compilation passes (`pnpm run build`), and the code properly utilizes server-authoritative query lookups in place of trusted document attributes.

---
*PR created automatically by Jules for task [5672844220302606683](https://jules.google.com/task/5672844220302606683) started by @DamienLove*