### PR TITLE
🎨 Palette: Forward focus to password input via wrapper click and improve accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2025-05-15 - Password Wrapper Focus
+**Learning:** Adding an onClick handler to an input wrapper to forward focus improves UX by making the whole visual container interactive, but it requires stopping propagation on inner interactive elements (like the password visibility toggle) to prevent them from unintentionally stealing focus back or causing conflicting interactions.
+**Action:** When making input wrappers interactive, always add `e.stopPropagation()` to the `onClick` handlers of any inner buttons, and pair `aria-pressed` with a static `aria-label` for standard toggle button accessibility.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2570,6 +2570,7 @@ function App() {
   const messagesEndRef = useRef(null);
   const [premiumClaimActive, setPremiumClaimActive] = useState(false);
   const [proClaimActive, setProClaimActive] = useState(false);
+  const passwordInputRef = useRef(null);
 
   // Bolt: Stable handler to ensure images trigger scroll
   const handleImageLoad = useCallback(() => {
@@ -4313,9 +4314,10 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordInputRef.current?.focus()} role="presentation">
                   <input
                     id="login-password"
+                    ref={passwordInputRef}
                     className="login-input"
                     type={showPassword ? "text" : "password"}
                     value={password}
@@ -4326,8 +4328,9 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => { e.stopPropagation(); setShowPassword(!showPassword); }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (


### PR DESCRIPTION
💡 **What:** Added an `onClick` handler to the `.password-input-wrapper` to forward focus to the password input field when clicked. Updated the password visibility toggle button to use `e.stopPropagation()` and improved its accessibility attributes.

🎯 **Why:** Users expect "input-like" containers with icons and borders to be fully interactive. Clicking anywhere inside the visual boundaries of the password field should focus the input. The toggle button needed `e.stopPropagation()` so clicking it wouldn't re-trigger the wrapper's focus logic.

📸 **Before/After:** No visual changes, but clicking the empty space inside the password wrapper now focuses the input field.

♿ **Accessibility:**
- Added `role="presentation"` to the interactive wrapper `div`.
- Updated the toggle button from dynamically changing its `aria-label` to using a standard pattern: a static `aria-label="Toggle password visibility"` combined with `aria-pressed={showPassword}`, ensuring screen readers accurately announce the state.

---
*PR created automatically by Jules for task [3621549470299601310](https://jules.google.com/task/3621549470299601310) started by @DamienLove*