### PR TITLE
🎨 Palette: Make password input wrapper fully interactive

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2025-05-15 - Input Wrapper Accessibility
+**Learning:** When making static input wrappers interactive (e.g., adding onClick to forward focus), screen readers might incorrectly announce them as interactive elements unless marked with role="presentation". Additionally, inner interactive elements (like toggle buttons) need e.stopPropagation() to prevent unintended side effects.
+**Action:** Always add role="presentation" to static wrapper elements when adding focus-forwarding onClick handlers, and use e.stopPropagation() on inner interactive elements.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2568,6 +2568,7 @@ function App() {
   const contactSearchRef = useRef(null);
   const themeSearchRef = useRef(null);
   const messagesEndRef = useRef(null);
+  const passwordInputRef = useRef(null);
   const [premiumClaimActive, setPremiumClaimActive] = useState(false);
   const [proClaimActive, setProClaimActive] = useState(false);
 
@@ -4313,8 +4314,13 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div
+                  className="password-input-wrapper"
+                  onClick={() => passwordInputRef.current?.focus()}
+                  role="presentation"
+                >
                   <input
+                    ref={passwordInputRef}
                     id="login-password"
                     className="login-input"
                     type={showPassword ? "text" : "password"}
@@ -4326,7 +4332,10 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
                     aria-label={showPassword ? "Hide password" : "Show password"}
                     title={showPassword ? "Hide password" : "Show password"}
                   >


### PR DESCRIPTION
### 💡 What
Made the password input wrapper fully interactive by forwarding focus to the inner `<input>` when clicked, along with necessary accessibility enhancements.

### 🎯 Why
Users expect "input-like" containers (with borders/backgrounds) to be fully interactive. Previously, clicking in the padding of the password wrapper did nothing, forcing users to click exactly inside the text field. This enhancement reduces friction and improves usability.

### ♿ Accessibility
- Added `role="presentation"` to the `div` wrapper to ensure screen readers don't mistakenly announce the structural wrapper as a separate interactive element.
- Added `e.stopPropagation()` to the password visibility toggle button to prevent unintended focus side effects when toggling visibility.

---
*PR created automatically by Jules for task [13868489849865468776](https://jules.google.com/task/13868489849865468776) started by @DamienLove*