### PR TITLE
🎨 Palette: Interactive Password Input Wrapper

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+## 2025-05-16 - Password Input Focus Forwarding
+**Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
+**Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2568,6 +2568,7 @@ function App() {
   const contactSearchRef = useRef(null);
   const themeSearchRef = useRef(null);
   const messagesEndRef = useRef(null);
+  const passwordInputRef = useRef(null);
   const [premiumClaimActive, setPremiumClaimActive] = useState(false);
   const [proClaimActive, setProClaimActive] = useState(false);
 
@@ -4313,9 +4314,14 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div
+                  className="password-input-wrapper"
+                  onClick={() => passwordInputRef.current?.focus()}
+                  role="presentation"
+                >
                   <input
                     id="login-password"
+                    ref={passwordInputRef}
                     className="login-input"
                     type={showPassword ? "text" : "password"}
                     value={password}
@@ -4326,7 +4332,10 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
                     aria-label={showPassword ? "Hide password" : "Show password"}
                     title={showPassword ? "Hide password" : "Show password"}
                   >


### PR DESCRIPTION
💡 **What:** Added an `onClick` handler to the `password-input-wrapper` div that forwards focus to the inner password input, and added `e.stopPropagation()` to the toggle button. Also recorded this as a learning in `.jules/palette.md`.
🎯 **Why:** Users naturally expect to click anywhere within an input-like container (with borders/icons) to start typing. Clicking near the edge of the password input previously did nothing. This reduces friction.
📸 **Before/After:** Clicking the empty space next to the password toggle button now properly focuses the password input field.
♿ **Accessibility:** Added `role="presentation"` to the wrapper `div` to ensure screen readers don't misinterpret the static container as a standalone interactive widget, while maintaining the UX improvement for sighted users.

---
*PR created automatically by Jules for task [10671199233147653004](https://jules.google.com/task/10671199233147653004) started by @DamienLove*