### PR TITLE
🎨 Palette: Improve password input UX and accessibility

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2526,6 +2526,7 @@ function App() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const passwordRef = useRef(null);
   const [authError, setAuthError] = useState('');
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [activePanel, setActivePanel] = useState('inbox');
@@ -4313,9 +4314,10 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div className="password-input-wrapper" onClick={() => passwordRef.current?.focus()} role="presentation">
                   <input
                     id="login-password"
+                    ref={passwordRef}
                     className="login-input"
                     type={showPassword ? "text" : "password"}
                     value={password}
@@ -4326,8 +4328,12 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (


### PR DESCRIPTION
💡 What: 
- Made the `password-input-wrapper` container interactive by forwarding clicks directly to the underlying password input field.
- Refactored the password visibility toggle button to use a static `aria-label` with dynamic `aria-pressed={showPassword}`.
- Added `e.stopPropagation()` to the toggle button to prevent clicks from bubbling up to the wrapper element and refocusing the input unnecessarily.

🎯 Why: 
Users expect input containers with icons or inner buttons (like our password container) to act as a single clickable target to focus the input, reducing friction. Additionally, screen readers expect stateful toggle buttons to use `aria-pressed` or `aria-expanded` with a static label rather than dynamically swapping the `aria-label` text.

📸 Before/After: 
- **Before:** Clicking outside the password input box but inside the input wrapper did not focus the input. The visibility toggle button dynamically changed its `aria-label` when clicked.
- **After:** Clicking anywhere in the password container focuses the password field. The visibility toggle correctly relays state using ARIA attributes and doesn't interfere with the wrapper's new focus forwarding mechanism.

♿ Accessibility:
- Forwarding clicks from non-interactive wrappers required adding `role="presentation"` to bypass strict linter requirements (`jsx-a11y/no-static-element-interactions`).
- Refactored dynamic `aria-label` into `aria-pressed` on the "Show Password" toggle, which is the recommended accessibility pattern for state buttons.

---
*PR created automatically by Jules for task [11555034276278518953](https://jules.google.com/task/11555034276278518953) started by @DamienLove*