### PR TITLE
🎨 Palette: Make password wrapper interactive

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+
+## 2025-05-18 - Clickable Password Wrapper
+**Learning:** Users expect custom wrappers around inputs to pass focus down. If a password wrapper contains a toggle button, clicking the wrapper should focus the input.
+**Action:** Add onClick and role='presentation' to password input wrappers, using e.stopPropagation on children buttons to prevent double-firing.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2568,6 +2568,7 @@ function App() {
   const contactSearchRef = useRef(null);
   const themeSearchRef = useRef(null);
   const messagesEndRef = useRef(null);
+  const loginPasswordRef = useRef(null);
   const [premiumClaimActive, setPremiumClaimActive] = useState(false);
   const [proClaimActive, setProClaimActive] = useState(false);
 
@@ -4313,8 +4314,13 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div
+                  className="password-input-wrapper"
+                  onClick={() => loginPasswordRef.current?.focus()}
+                  role="presentation"
+                >
                   <input
+                    ref={loginPasswordRef}
                     id="login-password"
                     className="login-input"
                     type={showPassword ? "text" : "password"}
@@ -4326,7 +4332,10 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
                     aria-label={showPassword ? "Hide password" : "Show password"}
                     title={showPassword ? "Hide password" : "Show password"}
                   >


### PR DESCRIPTION
🎨 Palette: Interactive Password Input Wrapper

- 💡 What: Added onClick forwarding to the custom `password-input-wrapper` div and stopped event propagation on the inner toggle button.
- 🎯 Why: Users expect custom wrappers around inputs to act as part of the input itself. Clicking the container's padding should naturally focus the input, reducing friction.
- 📸 Before/After: Clicking anywhere inside the neon border now focuses the password field seamlessly.
- ♿ Accessibility: Added `role="presentation"` to the `div` since the inner `<input>` is already the focusable interactive element.

---
*PR created automatically by Jules for task [8992172626418413886](https://jules.google.com/task/8992172626418413886) started by @DamienLove*