### PR TITLE
🎨 Palette: Improve password input interactive container and toggle accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+
+## 2025-05-20 - Accessible Interactive Toggle Buttons
+**Learning:** When using an interactive icon to toggle state (like a show/hide password button), dynamic aria-labels can confuse screen readers. Standard W3C ARIA practices prefer a static `aria-label` (e.g. 'Toggle password visibility') coupled with a dynamic `aria-pressed` attribute to clearly denote state changes without context shifting.
+**Action:** Always use static `aria-label` combined with dynamic `aria-pressed` for UI toggle buttons rather than mutating the label text.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -4313,7 +4313,11 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div
+                  className="password-input-wrapper"
+                  onClick={() => document.getElementById('login-password')?.focus()}
+                  role="presentation"
+                >
                   <input
                     id="login-password"
                     className="login-input"
@@ -4326,8 +4330,12 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (


### PR DESCRIPTION
💡 **What:** 
- Added an `onClick` handler to the password input wrapper to forward focus to the input field, increasing the hit area and making it feel like a fully interactive container.
- Added `role="presentation"` to the wrapper to adhere to accessibility guidelines for interactive static wrappers.
- Updated the password toggle button to call `e.stopPropagation()` so clicks don't bubble up and awkwardly re-focus the input.
- Changed the password toggle button's `aria-label` to be static ("Toggle password visibility") and added `aria-pressed` for better screen reader accessibility state management.

🎯 **Why:** 
Users expect input containers with visible boundaries and icons to be fully clickable to focus the input. The previous implementation only focused the input if the text field itself was clicked. Additionally, standard W3C ARIA toggle patterns prefer a static `aria-label` with a dynamic `aria-pressed` attribute, rather than shifting the label text entirely, which provides a much smoother screen reader experience.

📸 **Before/After:** 
- Before: Clicking the outer edge of the password input container did nothing. Screen readers heard a changing label text on the toggle button without explicit state toggling context.
- After: Clicking anywhere in the password input container focuses the input. Screen readers hear a consistent label and a clear pressed/unpressed state change.

♿ **Accessibility:** 
- The interactive wrapper strictly uses `role="presentation"` to avoid confusing screen readers with a `div` that handles clicks while delegating to an inner input.
- Adopted the standard ARIA toggle button pattern (`aria-label` + `aria-pressed`) instead of dynamically mutating `aria-label` for state changes.

---
*PR created automatically by Jules for task [17055792945622857404](https://jules.google.com/task/17055792945622857404) started by @DamienLove*