### PR TITLE
🎨 Palette: Improve password toggle interaction and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - Interactive Containers
 **Learning:** Users expect "input-like" containers (with icons and borders) to be fully interactive. Making the parent div focus the input on click reduces friction.
 **Action:** Always add onClick handlers to custom input wrappers to forward focus to the inner input.
+
+## 2025-05-16 - Password Toggle Accessibility
+**Learning:** Screen readers expect state toggle buttons to use aria-pressed with a static aria-label, rather than dynamically changing the text.
+**Action:** Always use a static aria-label with aria-pressed for boolean toggle buttons.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -4313,7 +4313,11 @@ function App() {
               </label>
               <div className="login-field">
                 <label htmlFor="login-password">Password</label>
-                <div className="password-input-wrapper">
+                <div
+                  className="password-input-wrapper"
+                  role="presentation"
+                  onClick={() => document.getElementById('login-password')?.focus()}
+                >
                   <input
                     id="login-password"
                     className="login-input"
@@ -4326,8 +4330,12 @@ function App() {
                   <button
                     type="button"
                     className="password-toggle-btn"
-                    onClick={() => setShowPassword(!showPassword)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowPassword(!showPassword);
+                    }}
+                    aria-label="Toggle password visibility"
+                    aria-pressed={showPassword}
                     title={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? (


### PR DESCRIPTION
🎨 Palette: Improved password toggle accessibility

**💡 What:**
- Added `onClick` and `role="presentation"` to the `password-input-wrapper` container to seamlessly forward focus to the inner password `<input>` when any part of the wrapper is clicked.
- Updated the show/hide password `<button>` to use a static `aria-label` ("Toggle password visibility") combined with the `aria-pressed` boolean attribute to accurately indicate state to screen readers.
- Added `e.stopPropagation()` to the toggle button's `onClick` to prevent redundant triggering of the wrapper's new focus-forwarding logic.

**🎯 Why:**
- Screen reader users expect state-toggling buttons (like show/hide password) to utilize `aria-pressed` instead of dynamically altering their `aria-label` text, as it correctly announces state changes without needing to reread the entire label.
- For mouse and touch users, it's a common interaction pattern to expect clicking anywhere within an "input-like" bordered container (including empty space next to icons) to automatically focus the actual text input field, reducing friction.

**📸 Before/After:**
*(Visual changes are subtle; interactions are enhanced. Verified via Playwright testing).*

**♿ Accessibility:**
- Screen readers will now announce "Toggle password visibility, toggle button, [pressed/not pressed]", which is standard and unambiguous. 
- The wrapper is marked with `role="presentation"` to prevent screen readers from interpreting the focus-forwarding `div` as a standalone interactive element, routing them appropriately to the semantic `<input>` and `<button>`.

---
*PR created automatically by Jules for task [7340207696332833483](https://jules.google.com/task/7340207696332833483) started by @DamienLove*